### PR TITLE
Updated locality in Norway

### DIFF
--- a/data/101/911/123/101911123.geojson
+++ b/data/101/911/123/101911123.geojson
@@ -20,54 +20,11 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
-    "name:ceb_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:deu_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
     "name:eng_x_preferred":[
-        "S. Jeronimo"
+        "Alversund"
     ],
-    "name:eng_x_variant":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:fra_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:ita_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:nld_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:pol_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:por_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:spa_x_colloquial":[
-        "S Jeronimo Verapaz",
-        "S. Jeronimo Verapaz",
-        "San Jeronimo",
-        "San Jeronimo Verapaz"
-    ],
-    "name:spa_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:spa_x_variant":[
-        "S Jer\u00f3nimo",
-        "S Jer\u00f3nimo Verapaz",
-        "S. Jer\u00f3nimo",
-        "S. Jer\u00f3nimo Verapaz",
-        "San Jer\u00f3nimo Verapaz"
-    ],
-    "name:swe_x_preferred":[
-        "San Jer\u00f3nimo"
-    ],
-    "name:zho_x_preferred":[
-        "\u8056\u8d6b\u7f85\u5c3c\u83ab"
+    "name:nno_x_preferred":[
+        "Alversund"
     ],
     "qs:a0":"Norge",
     "qs:a1":"*Hordaland",
@@ -96,14 +53,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fct:id":"1154f4ee-8f76-11e1-848f-cfd5bf3ef515",
-        "gn:id":3590114,
+        "gn:id":9536922,
         "gp:id":856595,
         "qs_pg:id":279805,
-        "wd:id":"Q962529",
-        "wk:page":"San Jer\u00f3nimo, Baja Verapaz"
-    },
-    "wof:concordances_alt":{
-        "qs_pg:id":1089180
+        "wd:id":"Q4737996",
+        "wk:page":"Alversund"
     },
     "wof:country":"NO",
     "wof:geomhash":"743dedbde62c6621d689ecbdac4e4207",
@@ -117,15 +71,10 @@
         }
     ],
     "wof:id":101911123,
-    "wof:lang":[
-        "spa"
-    ],
-    "wof:lastmodified":1571386326,
+    "wof:lastmodified":1573517078,
     "wof:name":"Alversund",
     "wof:parent_id":1159296745,
     "wof:placetype":"locality",
-    "wof:population":8093,
-    "wof:population_rank":5,
     "wof:repo":"whosonfirst-data-admin-no",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/101/911/123/101911123.geojson
+++ b/data/101/911/123/101911123.geojson
@@ -71,7 +71,16 @@
         }
     ],
     "wof:id":101911123,
-    "wof:lastmodified":1573517078,
+    "wof:lang_x_official":[
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nob",
+        "nno",
+        "sme"
+    ],
+    "wof:lastmodified":1573579628,
     "wof:name":"Alversund",
     "wof:parent_id":1159296745,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1730.

This PR untangles issues in the Alversund locality, removing bunk names, concordances, and other properties pulled from these concordances (ex: population). Name translations are only available for Norwegian and English for this locality, but names for "San Jeronimo" have been removed.

There are no geometry changes or PIP work needed, so this can be merged once approved.