### PR TITLE
Add label properties, update names and lang codes

### DIFF
--- a/data/149/511/597/1/1495115971.geojson
+++ b/data/149/511/597/1/1495115971.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "TR"
     ],
+    "label:nor_x_preferred_longname":[
+        "Tr\u00f8ndelag fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":63.130713,
     "lbl:longitude":11.433955,
     "lbl:min_zoom":8.0,
@@ -279,15 +285,17 @@
     ],
     "wof:id":1495115971,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1582313638,
+    "wof:lastmodified":1585695479,
     "wof:name":"Tr\u00f8ndelag",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/725/9/1527947259.geojson
+++ b/data/152/794/725/9/1527947259.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":69.720513,
     "geom:longitude":23.67876,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Troms and Finnmark County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Troms og Finnmark fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":69.596863,
     "lbl:longitude":24.270324,
     "mps:latitude":69.596863,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947259,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581017555,
+    "wof:lastmodified":1585695467,
     "wof:name":"Troms og Finnmark",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/1/1527947261.geojson
+++ b/data/152/794/726/1/1527947261.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":60.923062,
     "geom:longitude":6.424921,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Vestland County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Vestland fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":60.71471,
     "lbl:longitude":6.380577,
     "mps:latitude":60.71471,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947261,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581018763,
+    "wof:lastmodified":1585695473,
     "wof:name":"Vestland",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/3/1527947263.geojson
+++ b/data/152/794/726/3/1527947263.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":61.445034,
     "geom:longitude":10.42603,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Innlandet County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Innlandet fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":61.499768,
     "lbl:longitude":10.468031,
     "mps:latitude":61.499768,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947263,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581019057,
+    "wof:lastmodified":1585695476,
     "wof:name":"Innlandet",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/5/1527947265.geojson
+++ b/data/152/794/726/5/1527947265.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":58.697659,
     "geom:longitude":7.624011,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Agder County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Agder fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":58.700029,
     "lbl:longitude":7.348824,
     "mps:latitude":58.700029,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947265,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581019520,
+    "wof:lastmodified":1585695477,
     "wof:name":"Agder",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/7/1527947267.geojson
+++ b/data/152/794/726/7/1527947267.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":59.492971,
     "geom:longitude":8.718596,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Vestfold and Telemark County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Vestfold og Telemark fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":59.546564,
     "lbl:longitude":8.536491,
     "mps:latitude":59.546564,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947267,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581019709,
+    "wof:lastmodified":1585695472,
     "wof:name":"Vestfold og Telemark",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/9/1527947269.geojson
+++ b/data/152/794/726/9/1527947269.geojson
@@ -11,6 +11,18 @@
     "geom:latitude":60.082684,
     "geom:longitude":9.910491,
     "iso:country":"NO",
+    "label:eng_x_preferred_longname":[
+        "Viken County"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "county"
+    ],
+    "label:nor_x_preferred_longname":[
+        "Viken fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":60.017878,
     "lbl:longitude":9.869329,
     "mps:latitude":60.017878,
@@ -40,15 +52,17 @@
     ],
     "wof:id":1527947269,
     "wof:lang_x_official":[
+        "nor",
+        "nob",
+        "nno"
+    ],
+    "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lang_x_spoken":[
-        "nob",
-        "nno"
-    ],
-    "wof:lastmodified":1581020326,
+    "wof:lastmodified":1585695470,
     "wof:name":"Viken",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/856/333/41/85633341.geojson
+++ b/data/856/333/41/85633341.geojson
@@ -1220,15 +1220,17 @@
     ],
     "wof:id":85633341,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1583797404,
+    "wof:lastmodified":1585695743,
     "wof:name":"Norway",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/755/39/85675539.geojson
+++ b/data/856/755/39/85675539.geojson
@@ -23,6 +23,9 @@
     "label:eng_x_preferred_shortcode":[
         "SV"
     ],
+    "label:nor_x_preferred_longname":[
+        "Svalbard"
+    ],
     "lbl:latitude":78.778238,
     "lbl:longitude":18.080645,
     "lbl:min_zoom":8.0,
@@ -399,15 +402,17 @@
     ],
     "wof:id":85675539,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1583797429,
+    "wof:lastmodified":1585695455,
     "wof:name":"Svalbard",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/870/85/85687085.geojson
+++ b/data/856/870/85/85687085.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "RO"
     ],
+    "label:nor_x_preferred_longname":[
+        "Rogaland fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":58.585222,
     "lbl:longitude":6.235721,
     "lbl:min_zoom":8.0,
@@ -380,15 +386,17 @@
     ],
     "wof:id":85687085,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1582313551,
+    "wof:lastmodified":1585695456,
     "wof:name":"Rogaland",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/856/870/89/85687089.geojson
+++ b/data/856/870/89/85687089.geojson
@@ -19,6 +19,12 @@
     "label:eng_x_preferred_shortcode":[
         "OS"
     ],
+    "label:nor_x_preferred_longname":[
+        "Oslo fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
+    ],
     "lbl:latitude":60.015898,
     "lbl:longitude":10.704386,
     "lbl:min_zoom":8.0,
@@ -392,6 +398,9 @@
         "Oslo"
     ],
     "name:nor_x_preferred":[
+        "Oslo"
+    ],
+    "name:nor_x_variant":[
         "Oslo Fylke"
     ],
     "name:nov_x_preferred":[
@@ -725,15 +734,17 @@
     ],
     "wof:id":85687089,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1582313550,
+    "wof:lastmodified":1585695455,
     "wof:name":"Oslo",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/856/871/23/85687123.geojson
+++ b/data/856/871/23/85687123.geojson
@@ -11,13 +11,19 @@
     "geom:longitude":7.572172,
     "iso:country":"NO",
     "label:eng_x_preferred_longname":[
-        "M\u00f8re og Romsdal County"
+        "M\u00f8re and Romsdal County"
     ],
     "label:eng_x_preferred_placetype":[
         "county"
     ],
     "label:eng_x_preferred_shortcode":[
         "MR"
+    ],
+    "label:nor_x_preferred_longname":[
+        "M\u00f8re og Romsdal fylke"
+    ],
+    "label:nor_x_preferred_placetype":[
+        "fylke"
     ],
     "lbl:latitude":62.460157,
     "lbl:longitude":7.959662,
@@ -74,6 +80,9 @@
         "M\u00f8re og Romsdal"
     ],
     "name:eng_x_preferred":[
+        "M\u00f8re and Romsdal"
+    ],
+    "name:eng_x_variant":[
         "M\u00f8re og Romsdal"
     ],
     "name:epo_x_preferred":[
@@ -359,15 +368,17 @@
     ],
     "wof:id":85687123,
     "wof:lang_x_official":[
+        "nor",
         "nob",
         "nno"
     ],
     "wof:lang_x_spoken":[
+        "nor",
         "nob",
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1582313566,
+    "wof:lastmodified":1585695464,
     "wof:name":"M\u00f8re og Romsdal",
     "wof:parent_id":85633341,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640

This PR:
- Adds/updates `label` properties to Norway regions
- Updates `wof:lang*` properties in all regions and country records
- Corrects `name` property values, storing variant names when applicable

No PIP work required, can merge once approved.