### PR TITLE
Flag coterminous places

### DIFF
--- a/data/115/929/716/7/1159297167.geojson
+++ b/data/115/929/716/7/1159297167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072969,
-    "geom:area_square_m":478112518.202648,
+    "geom:area_square_m":451394820.8494,
     "geom:bbox":"10.489165,59.809311,10.951389,60.135106",
     "geom:latitude":59.981202,
     "geom:longitude":10.739271,
@@ -588,7 +588,8 @@
         "no-geonorge:kommunenum":301
     },
     "wof:coterminous":[
-        1495123997
+        1495123997,
+        85687089
     ],
     "wof:country":"NO",
     "wof:created":1524595900,
@@ -611,7 +612,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1584030685,
+    "wof:lastmodified":1608002767,
     "wof:name":"Oslo",
     "wof:parent_id":85687089,
     "wof:placetype":"localadmin",

--- a/data/149/512/399/7/1495123997.geojson
+++ b/data/149/512/399/7/1495123997.geojson
@@ -812,7 +812,8 @@
         "wk:page":"Oslo"
     },
     "wof:coterminous":[
-        1159297167
+        1159297167,
+        85687089
     ],
     "wof:country":"NO",
     "wof:created":1570830024,
@@ -827,7 +828,7 @@
         }
     ],
     "wof:id":1495123997,
-    "wof:lastmodified":1607462726,
+    "wof:lastmodified":1608002801,
     "wof:megacity":1,
     "wof:name":"Oslo",
     "wof:parent_id":1159297167,

--- a/data/856/870/89/85687089.geojson
+++ b/data/856/870/89/85687089.geojson
@@ -723,6 +723,10 @@
         "unlc:id":"NO-03",
         "wd:id":"Q585"
     },
+    "wof:coterminous":[
+        1159297167,
+        1495123997
+    ],
     "wof:country":"NO",
     "wof:geom_alt":[
         "quattroshapes-reversegeo"
@@ -747,7 +751,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1607462699,
+    "wof:lastmodified":1608002802,
     "wof:name":"Oslo",
     "wof:parent_id":85633341,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1906.

This PR attempts flag any locality, localadmin, county, macrocounty, or region record as coterminous with any parent records that are similar in size and have similar names.