### PR TITLE
Fix bergen superseding

### DIFF
--- a/data/149/516/580/1/1495165801.geojson
+++ b/data/149/516/580/1/1495165801.geojson
@@ -526,7 +526,7 @@
     "wof:lang":[
         "nor"
     ],
-    "wof:lastmodified":1607462718,
+    "wof:lastmodified":1689307885,
     "wof:megacity":0,
     "wof:name":"Bergen",
     "wof:parent_id":1159297617,
@@ -535,9 +535,7 @@
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-no",
     "wof:scale":3,
-    "wof:superseded_by":[
-        101751923
-    ],
+    "wof:superseded_by":[],
     "wof:supersedes":[
         101751923
     ],


### PR DESCRIPTION
This will fix https://github.com/whosonfirst-data/whosonfirst-data/issues/2148

This PR updates the supersedes properties in the locality record of Bergen. No PIP work needed, can merge once approved.

**Number of records updated**: 1