### PR TITLE
NO concordances, placetype local, and more

### DIFF
--- a/data/115/929/669/5/1159296695.geojson
+++ b/data/115/929/669/5/1159296695.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.006859,
     "geom:longitude":14.043637,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.986585,
     "lbl:longitude":13.9895,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578137,
         "eg:gisco_id":"NO_1832",
         "eurostat:nuts_2021_id":"1832",
-        "no-geonorge:kommunenum":1832
+        "no-geonorge:kommunenum":1832,
+        "no-geonorge:number":"1832"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595726,
     "wof:geomhash":"72ee77e6789e1df81eff14cb0a5fa808",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354067,
+    "wof:lastmodified":1695878839,
     "wof:name":"Hemnes",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/669/7/1159296697.geojson
+++ b/data/115/929/669/7/1159296697.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.551416,
     "geom:longitude":9.072526,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.521457,
     "lbl:longitude":9.098125,
     "lbl:max_zoom":18.0,
@@ -133,8 +142,10 @@
         "digitalenvoy:metro_code":578241,
         "eg:gisco_id":"NO_3040",
         "eurostat:nuts_2021_id":"3040",
-        "no-geonorge:kommunenum":3040
+        "no-geonorge:kommunenum":3040,
+        "no-geonorge:number":"3040"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595728,
     "wof:geomhash":"83f82461ef3571672157c7e8efa32730",
@@ -156,7 +167,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878839,
     "wof:name":"Nesbyen",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/669/9/1159296699.geojson
+++ b/data/115/929/669/9/1159296699.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.996159,
     "geom:longitude":10.850448,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.011827,
     "lbl:longitude":10.855392,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578294,
         "eg:gisco_id":"NO_3411",
         "eurostat:nuts_2021_id":"3411",
-        "no-geonorge:kommunenum":3411
+        "no-geonorge:kommunenum":3411,
+        "no-geonorge:number":"3411"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595729,
     "wof:geomhash":"5a289973a46ed7c09ec77abf42710e73",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878839,
     "wof:name":"Ringsaker",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/670/1/1159296701.geojson
+++ b/data/115/929/670/1/1159296701.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.319878,
     "geom:longitude":10.536031,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.306628,
     "lbl:longitude":10.530949,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578275,
         "eg:gisco_id":"NO_3440",
         "eurostat:nuts_2021_id":"3440",
-        "no-geonorge:kommunenum":3440
+        "no-geonorge:kommunenum":3440,
+        "no-geonorge:number":"3440"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595734,
     "wof:geomhash":"abedead08810b4a51999c50483f1dc51",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878840,
     "wof:name":"\u00d8yer",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/670/7/1159296707.geojson
+++ b/data/115/929/670/7/1159296707.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.708258,
     "geom:longitude":5.770795,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.694977,
     "lbl:longitude":5.798004,
     "lbl:max_zoom":18.0,
@@ -496,8 +505,10 @@
         "digitalenvoy:metro_code":578375,
         "eg:gisco_id":"NO_1121",
         "eurostat:nuts_2021_id":"1121",
-        "no-geonorge:kommunenum":1121
+        "no-geonorge:kommunenum":1121,
+        "no-geonorge:number":"1121"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595735,
     "wof:geomhash":"69b17a81b6a4f5dcb4001c34b22c84f9",
@@ -519,7 +530,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878840,
     "wof:name":"Time",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/670/9/1159296709.geojson
+++ b/data/115/929/670/9/1159296709.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.447264,
     "geom:longitude":5.293204,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.436499,
     "lbl:longitude":5.303439,
     "lbl:max_zoom":18.0,
@@ -223,8 +232,10 @@
         "digitalenvoy:metro_code":578135,
         "eg:gisco_id":"NO_1106",
         "eurostat:nuts_2021_id":"1106",
-        "no-geonorge:kommunenum":1106
+        "no-geonorge:kommunenum":1106,
+        "no-geonorge:number":"1106"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595735,
     "wof:geomhash":"784e749d31a150ca3b04e6ff690e4f6b",
@@ -246,7 +257,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878840,
     "wof:name":"Haugesund",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/671/1/1159296711.geojson
+++ b/data/115/929/671/1/1159296711.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.464937,
     "geom:longitude":11.212607,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.458968,
     "lbl:longitude":11.219733,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578357,
         "eg:gisco_id":"NO_5035",
         "eurostat:nuts_2021_id":"5035",
-        "no-geonorge:kommunenum":5035
+        "no-geonorge:kommunenum":5035,
+        "no-geonorge:number":"5035"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595736,
     "wof:geomhash":"9e77328d254bbd26af2c56187fafdefb",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878840,
     "wof:name":"Stj\u00f8rdal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/671/3/1159296713.geojson
+++ b/data/115/929/671/3/1159296713.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.086551,
     "geom:longitude":11.497051,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.087856,
     "lbl:longitude":11.536038,
     "lbl:max_zoom":18.0,
@@ -193,8 +202,10 @@
         "digitalenvoy:metro_code":578125,
         "eg:gisco_id":"NO_3001",
         "eurostat:nuts_2021_id":"3001",
-        "no-geonorge:kommunenum":3001
+        "no-geonorge:kommunenum":3001,
+        "no-geonorge:number":"3001"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595736,
     "wof:geomhash":"305de9ea5934f3e387af19fd47cdb85b",
@@ -216,7 +227,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354068,
+    "wof:lastmodified":1695878840,
     "wof:name":"Halden",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/671/7/1159296717.geojson
+++ b/data/115/929/671/7/1159296717.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.902215,
     "geom:longitude":10.53426,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.881165,
     "lbl:longitude":10.534165,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578226,
         "eg:gisco_id":"NO_5027",
         "eurostat:nuts_2021_id":"5027",
-        "no-geonorge:kommunenum":5027
+        "no-geonorge:kommunenum":5027,
+        "no-geonorge:number":"5027"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595737,
     "wof:geomhash":"c9163bfca70bfa51c92d0ca8415feeee",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354069,
+    "wof:lastmodified":1695878840,
     "wof:name":"Midtre Gauldal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/672/1/1159296721.geojson
+++ b/data/115/929/672/1/1159296721.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.421148,
     "geom:longitude":6.200263,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.421281,
     "lbl:longitude":6.202605,
     "lbl:max_zoom":18.0,
@@ -130,13 +139,15 @@
         "digitalenvoy:metro_code":578366,
         "eg:gisco_id":"NO_1531",
         "eurostat:nuts_2021_id":"1531",
-        "no-geonorge:kommunenum":1531
+        "no-geonorge:kommunenum":1531,
+        "no-geonorge:number":"1531"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578313
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595738,
     "wof:geomhash":"482d8cf057f59fe20ec38a4d5cc22850",
@@ -158,7 +169,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354069,
+    "wof:lastmodified":1695878840,
     "wof:name":"Sula",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/672/9/1159296729.geojson
+++ b/data/115/929/672/9/1159296729.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.223794,
     "geom:longitude":11.753721,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.224164,
     "lbl:longitude":11.757689,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578347,
         "eg:gisco_id":"NO_3415",
         "eurostat:nuts_2021_id":"3415",
-        "no-geonorge:kommunenum":3415
+        "no-geonorge:kommunenum":3415,
+        "no-geonorge:number":"3415"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595740,
     "wof:geomhash":"9ce2aeff4a2ebc1c1cb525f2d7fa2f27",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354069,
+    "wof:lastmodified":1695878840,
     "wof:name":"S\u00f8r-Odal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/673/1/1159296731.geojson
+++ b/data/115/929/673/1/1159296731.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.888833,
     "geom:longitude":8.978584,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.907391,
     "lbl:longitude":8.963681,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578109,
         "eg:gisco_id":"NO_4211",
         "eurostat:nuts_2021_id":"4211",
-        "no-geonorge:kommunenum":4211
+        "no-geonorge:kommunenum":4211,
+        "no-geonorge:number":"4211"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595741,
     "wof:geomhash":"3c29c866f4429692d41420856033db10",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354069,
+    "wof:lastmodified":1695878841,
     "wof:name":"Gjerstad",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/673/5/1159296735.geojson
+++ b/data/115/929/673/5/1159296735.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.232496,
     "geom:longitude":5.581729,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.22645,
     "lbl:longitude":5.673305,
     "lbl:max_zoom":18.0,
@@ -121,8 +130,10 @@
         "digitalenvoy:metro_code":578310,
         "eg:gisco_id":"NO_1514",
         "eurostat:nuts_2021_id":"1514",
-        "no-geonorge:kommunenum":1514
+        "no-geonorge:kommunenum":1514,
+        "no-geonorge:number":"1514"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595742,
     "wof:geomhash":"eebabf2663a3c4f487d9b29604f1a969",
@@ -144,7 +155,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354069,
+    "wof:lastmodified":1695878841,
     "wof:name":"Sande",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/673/7/1159296737.geojson
+++ b/data/115/929/673/7/1159296737.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.244819,
     "geom:longitude":9.097729,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.204446,
     "lbl:longitude":9.154006,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578277,
         "eg:gisco_id":"NO_3453",
         "eurostat:nuts_2021_id":"3453",
-        "no-geonorge:kommunenum":3453
+        "no-geonorge:kommunenum":3453,
+        "no-geonorge:number":"3453"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595748,
     "wof:geomhash":"e6a58347d0376b2121c74f1ab3bf8e57",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354070,
+    "wof:lastmodified":1695878841,
     "wof:name":"\u00d8ystre Slidre",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/673/9/1159296739.geojson
+++ b/data/115/929/673/9/1159296739.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.349663,
     "geom:longitude":6.657127,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.350966,
     "lbl:longitude":6.680438,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578373,
         "eg:gisco_id":"NO_1528",
         "eurostat:nuts_2021_id":"1528",
-        "no-geonorge:kommunenum":1528
+        "no-geonorge:kommunenum":1528,
+        "no-geonorge:number":"1528"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595749,
     "wof:geomhash":"da09b108e1834796102a571efbb068ff",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354070,
+    "wof:lastmodified":1695878841,
     "wof:name":"Sykkylven",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/674/3/1159296743.geojson
+++ b/data/115/929/674/3/1159296743.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.486686,
     "geom:longitude":14.986589,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.436865,
     "lbl:longitude":15.238461,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578123,
         "eg:gisco_id":"NO_1866",
         "eurostat:nuts_2021_id":"1866",
-        "no-geonorge:kommunenum":1866
+        "no-geonorge:kommunenum":1866,
+        "no-geonorge:number":"1866"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595749,
     "wof:geomhash":"dbd87b0759e1cee1354d7c14220e8aec",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354070,
+    "wof:lastmodified":1695878841,
     "wof:name":"Hadsel",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/674/7/1159296747.geojson
+++ b/data/115/929/674/7/1159296747.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.429532,
     "geom:longitude":10.514403,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.444946,
     "lbl:longitude":10.506669,
     "lbl:max_zoom":18.0,
@@ -118,8 +127,10 @@
         "digitalenvoy:metro_code":578114,
         "eg:gisco_id":"NO_3446",
         "eurostat:nuts_2021_id":"3446",
-        "no-geonorge:kommunenum":3446
+        "no-geonorge:kommunenum":3446,
+        "no-geonorge:number":"3446"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595750,
     "wof:geomhash":"3dfc2589dc4404fed7c4d79628570f43",
@@ -141,7 +152,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354070,
+    "wof:lastmodified":1695878842,
     "wof:name":"Gran",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/674/9/1159296749.geojson
+++ b/data/115/929/674/9/1159296749.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.292992,
     "geom:longitude":7.81452,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.302199,
     "lbl:longitude":7.821074,
     "lbl:max_zoom":18.0,
@@ -106,8 +115,10 @@
         "digitalenvoy:metro_code":578012,
         "eg:gisco_id":"NO_4643",
         "eurostat:nuts_2021_id":"4643",
-        "no-geonorge:kommunenum":4643
+        "no-geonorge:kommunenum":4643,
+        "no-geonorge:number":"4643"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595751,
     "wof:geomhash":"3986c04cc9f2e2013720f73b02fa47e3",
@@ -129,7 +140,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354070,
+    "wof:lastmodified":1695878842,
     "wof:name":"\u00c5rdal",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/675/1/1159296751.geojson
+++ b/data/115/929/675/1/1159296751.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.214213,
     "geom:longitude":27.625017,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.292798,
     "lbl:longitude":27.650569,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578055,
         "eg:gisco_id":"NO_5441",
         "eurostat:nuts_2021_id":"5441",
-        "no-geonorge:kommunenum":5441
+        "no-geonorge:kommunenum":5441,
+        "no-geonorge:number":"5441"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595751,
     "wof:geomhash":"4ee15da0cc5f4949147c29dadee9ed4c",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878842,
     "wof:name":"Tana",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/675/5/1159296755.geojson
+++ b/data/115/929/675/5/1159296755.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.118275,
     "geom:longitude":9.759439,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.120918,
     "lbl:longitude":9.75881,
     "lbl:max_zoom":18.0,
@@ -184,8 +193,10 @@
         "digitalenvoy:metro_code":578279,
         "eg:gisco_id":"NO_3806",
         "eurostat:nuts_2021_id":"3806",
-        "no-geonorge:kommunenum":3806
+        "no-geonorge:kommunenum":3806,
+        "no-geonorge:number":"3806"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595752,
     "wof:geomhash":"ee134974571eaefc1b6a4b8493483b0b",
@@ -207,7 +218,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878842,
     "wof:name":"Porsgrunn",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/675/7/1159296757.geojson
+++ b/data/115/929/675/7/1159296757.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.846094,
     "geom:longitude":11.033979,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.808162,
     "lbl:longitude":10.897867,
     "lbl:max_zoom":18.0,
@@ -56,8 +65,10 @@
         "digitalenvoy:metro_code":578159,
         "eg:gisco_id":"NO_5053",
         "eurostat:nuts_2021_id":"5053",
-        "no-geonorge:kommunenum":5053
+        "no-geonorge:kommunenum":5053,
+        "no-geonorge:number":"5053"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595752,
     "wof:geomhash":"89a6bd4ff77211c7b28c2b52eb3ca08e",
@@ -79,7 +90,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878842,
     "wof:name":"Inderoy",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/676/1/1159296761.geojson
+++ b/data/115/929/676/1/1159296761.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.462416,
     "geom:longitude":20.774595,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.412882,
     "lbl:longitude":20.727747,
     "lbl:max_zoom":18.0,
@@ -64,8 +73,10 @@
         "digitalenvoy:metro_code":578101,
         "eg:gisco_id":"NO_5426",
         "eurostat:nuts_2021_id":"5426",
-        "no-geonorge:kommunenum":5426
+        "no-geonorge:kommunenum":5426,
+        "no-geonorge:number":"5426"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595753,
     "wof:geomhash":"a3fdaf38605856e696f1cef2b660f6e2",
@@ -87,7 +98,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878843,
     "wof:name":"K\u00e5fjord",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/676/3/1159296763.geojson
+++ b/data/115/929/676/3/1159296763.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.982449,
     "geom:longitude":11.954374,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.949122,
     "lbl:longitude":11.961902,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578070,
         "eg:gisco_id":"NO_3425",
         "eurostat:nuts_2021_id":"3425",
-        "no-geonorge:kommunenum":3425
+        "no-geonorge:kommunenum":3425,
+        "no-geonorge:number":"3425"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595754,
     "wof:geomhash":"0bab651abf9fad4309758d5f9434f84a",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878843,
     "wof:name":"Engerdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/676/7/1159296767.geojson
+++ b/data/115/929/676/7/1159296767.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.679432,
     "geom:longitude":10.280007,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.70998,
     "lbl:longitude":10.315501,
     "lbl:max_zoom":18.0,
@@ -85,13 +94,15 @@
         "digitalenvoy:metro_code":578192,
         "eg:gisco_id":"NO_5054",
         "eurostat:nuts_2021_id":"5054",
-        "no-geonorge:kommunenum":5054
+        "no-geonorge:kommunenum":5054,
+        "no-geonorge:number":"5054"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578296
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595755,
     "wof:geomhash":"9bafc4ba8de2f00e55e31d8a811b25c9",
@@ -113,7 +124,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878843,
     "wof:name":"Indre Fosen",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/676/9/1159296769.geojson
+++ b/data/115/929/676/9/1159296769.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.868158,
     "geom:longitude":15.056177,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.901268,
     "lbl:longitude":15.139501,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578260,
         "eg:gisco_id":"NO_1868",
         "eurostat:nuts_2021_id":"1868",
-        "no-geonorge:kommunenum":1868
+        "no-geonorge:kommunenum":1868,
+        "no-geonorge:number":"1868"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595755,
     "wof:geomhash":"f0bc2111efc1ce4efb501e3d5eb8e59d",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354071,
+    "wof:lastmodified":1695878843,
     "wof:name":"\u00d8ksnes",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/677/1/1159296771.geojson
+++ b/data/115/929/677/1/1159296771.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.865406,
     "geom:longitude":13.010769,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.933724,
     "lbl:longitude":13.111419,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578235,
         "eg:gisco_id":"NO_5044",
         "eurostat:nuts_2021_id":"5044",
-        "no-geonorge:kommunenum":5044
+        "no-geonorge:kommunenum":5044,
+        "no-geonorge:number":"5044"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595755,
     "wof:geomhash":"635f20349f534a77490feff4da0b7ac8",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354072,
+    "wof:lastmodified":1695878843,
     "wof:name":"Namsskogan",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/677/5/1159296775.geojson
+++ b/data/115/929/677/5/1159296775.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.911603,
     "geom:longitude":19.379195,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.814219,
     "lbl:longitude":19.665613,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578213,
         "eg:gisco_id":"NO_5418",
         "eurostat:nuts_2021_id":"5418",
-        "no-geonorge:kommunenum":5418
+        "no-geonorge:kommunenum":5418,
+        "no-geonorge:number":"5418"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595756,
     "wof:geomhash":"6f0b2b48f0933644ac4f9acb77bac183",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354072,
+    "wof:lastmodified":1695878843,
     "wof:name":"M\u00e5lselv",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/677/9/1159296779.geojson
+++ b/data/115/929/677/9/1159296779.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.211326,
     "geom:longitude":9.959024,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.141368,
     "lbl:longitude":9.995448,
     "lbl:max_zoom":18.0,
@@ -205,13 +214,15 @@
         "digitalenvoy:metro_code":578186,
         "eg:gisco_id":"NO_3805",
         "eurostat:nuts_2021_id":"3805",
-        "no-geonorge:kommunenum":3805
+        "no-geonorge:kommunenum":3805,
+        "no-geonorge:number":"3805"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578185
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595757,
     "wof:geomhash":"407734dc8c5df2df58065fb0fa7d4107",
@@ -233,7 +244,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354072,
+    "wof:lastmodified":1695878844,
     "wof:name":"Larvik",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/678/1/1159296781.geojson
+++ b/data/115/929/678/1/1159296781.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.664023,
     "geom:longitude":11.918732,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.657978,
     "lbl:longitude":11.900554,
     "lbl:max_zoom":18.0,
@@ -252,8 +261,10 @@
     "wof:concordances":{
         "eg:gisco_id":"NO_1815",
         "eurostat:nuts_2021_id":"1815",
-        "no-geonorge:kommunenum":1815
+        "no-geonorge:kommunenum":1815,
+        "no-geonorge:number":"1815"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595757,
     "wof:geomhash":"cd35a15ba15549fc10678b474362f335",
@@ -275,7 +286,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354072,
+    "wof:lastmodified":1695878844,
     "wof:name":"Vega",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/678/5/1159296785.geojson
+++ b/data/115/929/678/5/1159296785.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.893292,
     "geom:longitude":7.822449,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.891817,
     "lbl:longitude":7.914037,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578107,
         "eg:gisco_id":"NO_1557",
         "eurostat:nuts_2021_id":"1557",
-        "no-geonorge:kommunenum":1557
+        "no-geonorge:kommunenum":1557,
+        "no-geonorge:number":"1557"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595763,
     "wof:geomhash":"87eb85fc726fbb0d53111dd22d87d1e6",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878844,
     "wof:name":"Gjemnes",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/678/7/1159296787.geojson
+++ b/data/115/929/678/7/1159296787.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.719142,
     "geom:longitude":6.167006,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.727193,
     "lbl:longitude":6.065329,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578112,
         "eg:gisco_id":"NO_4650",
         "eurostat:nuts_2021_id":"4650",
-        "no-geonorge:kommunenum":4650
+        "no-geonorge:kommunenum":4650,
+        "no-geonorge:number":"4650"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595764,
     "wof:geomhash":"2d46b2f31ac40a9447c49adea57bc9a4",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878845,
     "wof:name":"Gloppen",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/678/9/1159296789.geojson
+++ b/data/115/929/678/9/1159296789.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.472345,
     "geom:longitude":5.130815,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.472251,
     "lbl:longitude":5.162545,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578019,
         "eg:gisco_id":"NO_4627",
         "eurostat:nuts_2021_id":"4627",
-        "no-geonorge:kommunenum":4627
+        "no-geonorge:kommunenum":4627,
+        "no-geonorge:number":"4627"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595765,
     "wof:geomhash":"c097f391cb732cb4a52ef772b5c819b6",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878845,
     "wof:name":"Ask\u00f8y",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/679/3/1159296793.geojson
+++ b/data/115/929/679/3/1159296793.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.136618,
     "geom:longitude":9.454861,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.199484,
     "lbl:longitude":9.36437,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578321,
         "eg:gisco_id":"NO_3045",
         "eurostat:nuts_2021_id":"3045",
-        "no-geonorge:kommunenum":3045
+        "no-geonorge:kommunenum":3045,
+        "no-geonorge:number":"3045"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595766,
     "wof:geomhash":"70931253305ce1b86ff34b507669b730",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878845,
     "wof:name":"Sigdal",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/679/7/1159296797.geojson
+++ b/data/115/929/679/7/1159296797.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.430465,
     "geom:longitude":10.949242,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.423213,
     "lbl:longitude":11.004109,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578154,
         "eg:gisco_id":"NO_3037",
         "eurostat:nuts_2021_id":"3037",
-        "no-geonorge:kommunenum":3037
+        "no-geonorge:kommunenum":3037,
+        "no-geonorge:number":"3037"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595766,
     "wof:geomhash":"f9961ba007e652e63482a0526db592ec",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878845,
     "wof:name":"Hurdal",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/679/9/1159296799.geojson
+++ b/data/115/929/679/9/1159296799.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.246325,
     "geom:longitude":19.253843,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.226171,
     "lbl:longitude":19.113282,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578033,
         "eg:gisco_id":"NO_5422",
         "eurostat:nuts_2021_id":"5422",
-        "no-geonorge:kommunenum":5422
+        "no-geonorge:kommunenum":5422,
+        "no-geonorge:number":"5422"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595767,
     "wof:geomhash":"cc2c002cc19553435f8dbdd9f460673d",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354073,
+    "wof:lastmodified":1695878845,
     "wof:name":"Balsfjord",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/680/1/1159296801.geojson
+++ b/data/115/929/680/1/1159296801.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.786404,
     "geom:longitude":12.014383,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.755953,
     "lbl:longitude":12.024198,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578418,
         "eg:gisco_id":"NO_5038",
         "eurostat:nuts_2021_id":"5038",
-        "no-geonorge:kommunenum":5038
+        "no-geonorge:kommunenum":5038,
+        "no-geonorge:number":"5038"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595772,
     "wof:geomhash":"91315a7ecee13e9dbec288db39e66e83",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354074,
+    "wof:lastmodified":1695878845,
     "wof:name":"Verdal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/680/3/1159296803.geojson
+++ b/data/115/929/680/3/1159296803.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.498022,
     "geom:longitude":12.052286,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.521363,
     "lbl:longitude":12.106204,
     "lbl:max_zoom":18.0,
@@ -67,8 +76,10 @@
         "digitalenvoy:metro_code":578302,
         "eg:gisco_id":"NO_1856",
         "eurostat:nuts_2021_id":"1856",
-        "no-geonorge:kommunenum":1856
+        "no-geonorge:kommunenum":1856,
+        "no-geonorge:number":"1856"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595773,
     "wof:geomhash":"c36005f97f51ed2703eee2b886eb95ff",
@@ -90,7 +101,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354074,
+    "wof:lastmodified":1695878846,
     "wof:name":"R\u00f8st",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/680/5/1159296805.geojson
+++ b/data/115/929/680/5/1159296805.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.584033,
     "geom:longitude":8.714681,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.564802,
     "lbl:longitude":8.750049,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578369,
         "eg:gisco_id":"NO_1563",
         "eurostat:nuts_2021_id":"1563",
-        "no-geonorge:kommunenum":1563
+        "no-geonorge:kommunenum":1563,
+        "no-geonorge:number":"1563"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595780,
     "wof:geomhash":"772cc0093467990a0c17b5dbe642faf5",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354074,
+    "wof:lastmodified":1695878846,
     "wof:name":"Sunndal",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/680/7/1159296807.geojson
+++ b/data/115/929/680/7/1159296807.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.215581,
     "geom:longitude":12.218722,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.211312,
     "lbl:longitude":12.366312,
     "lbl:max_zoom":18.0,
@@ -175,8 +184,10 @@
         "digitalenvoy:metro_code":578171,
         "eg:gisco_id":"NO_3401",
         "eurostat:nuts_2021_id":"3401",
-        "no-geonorge:kommunenum":3401
+        "no-geonorge:kommunenum":3401,
+        "no-geonorge:number":"3401"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595786,
     "wof:geomhash":"3ade0abd599210ba252543e7d5f2c74d",
@@ -198,7 +209,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354074,
+    "wof:lastmodified":1695878846,
     "wof:name":"Kongsvinger",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/680/9/1159296809.geojson
+++ b/data/115/929/680/9/1159296809.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.572215,
     "geom:longitude":13.424128,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.505088,
     "lbl:longitude":13.479635,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578298,
         "eg:gisco_id":"NO_1836",
         "eurostat:nuts_2021_id":"1836",
-        "no-geonorge:kommunenum":1836
+        "no-geonorge:kommunenum":1836,
+        "no-geonorge:number":"1836"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595787,
     "wof:geomhash":"e82d7d35b08d33d7b46590ec2366f67e",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"R\u00f8d\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/681/1/1159296811.geojson
+++ b/data/115/929/681/1/1159296811.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.044868,
     "geom:longitude":10.294665,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.051079,
     "lbl:longitude":10.282654,
     "lbl:max_zoom":18.0,
@@ -73,8 +82,10 @@
         "digitalenvoy:metro_code":578147,
         "eg:gisco_id":"NO_3038",
         "eurostat:nuts_2021_id":"3038",
-        "no-geonorge:kommunenum":3038
+        "no-geonorge:kommunenum":3038,
+        "no-geonorge:number":"3038"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595787,
     "wof:geomhash":"3d8bd8578e7aa95b1d4a5c3d6e9d6cab",
@@ -96,7 +107,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"Hole",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/681/5/1159296815.geojson
+++ b/data/115/929/681/5/1159296815.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.892486,
     "geom:longitude":10.969317,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.894482,
     "lbl:longitude":10.968141,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578205,
         "eg:gisco_id":"NO_3029",
         "eurostat:nuts_2021_id":"3029",
-        "no-geonorge:kommunenum":3029
+        "no-geonorge:kommunenum":3029,
+        "no-geonorge:number":"3029"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595788,
     "wof:geomhash":"aa5429b951e5278271c1b60c3c5baf76",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"L\u00f8renskog",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/682/1/1159296821.geojson
+++ b/data/115/929/682/1/1159296821.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.372321,
     "geom:longitude":10.75757,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.355542,
     "lbl:longitude":10.759782,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578214,
         "eg:gisco_id":"NO_5031",
         "eurostat:nuts_2021_id":"5031",
-        "no-geonorge:kommunenum":5031
+        "no-geonorge:kommunenum":5031,
+        "no-geonorge:number":"5031"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595790,
     "wof:geomhash":"f409df4474c05a45e371152e161c6da0",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"Malvik",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/682/3/1159296823.geojson
+++ b/data/115/929/682/3/1159296823.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.010645,
     "geom:longitude":9.217306,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.016685,
     "lbl:longitude":9.213552,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578299,
         "eg:gisco_id":"NO_3051",
         "eurostat:nuts_2021_id":"3051",
-        "no-geonorge:kommunenum":3051
+        "no-geonorge:kommunenum":3051,
+        "no-geonorge:number":"3051"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595790,
     "wof:geomhash":"cac036ff80d7c093d5b8322f654ddfae",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"Rollag",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/683/3/1159296833.geojson
+++ b/data/115/929/683/3/1159296833.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.221697,
     "geom:longitude":15.807876,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.163756,
     "lbl:longitude":16.025359,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578076,
         "eg:gisco_id":"NO_1841",
         "eurostat:nuts_2021_id":"1841",
-        "no-geonorge:kommunenum":1841
+        "no-geonorge:kommunenum":1841,
+        "no-geonorge:number":"1841"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595792,
     "wof:geomhash":"ac3e5deb0a5c409d10fb55bb6e9e4701",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354075,
+    "wof:lastmodified":1695878847,
     "wof:name":"Fauske",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/683/7/1159296837.geojson
+++ b/data/115/929/683/7/1159296837.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.013008,
     "geom:longitude":9.532122,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.015656,
     "lbl:longitude":9.546025,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578034,
         "eg:gisco_id":"NO_3813",
         "eurostat:nuts_2021_id":"3813",
-        "no-geonorge:kommunenum":3813
+        "no-geonorge:kommunenum":3813,
+        "no-geonorge:number":"3813"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595794,
     "wof:geomhash":"9a08cc8a108f0374a4cc6285f3d16803",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"Bamble",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/684/1/1159296841.geojson
+++ b/data/115/929/684/1/1159296841.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.60896,
     "geom:longitude":10.890186,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.605778,
     "lbl:longitude":10.890192,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578272,
         "eg:gisco_id":"NO_3442",
         "eurostat:nuts_2021_id":"3442",
-        "no-geonorge:kommunenum":3442
+        "no-geonorge:kommunenum":3442,
+        "no-geonorge:number":"3442"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595795,
     "wof:geomhash":"f6340a66948f2729096f10d36374d758",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"\u00d8stre Toten",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/684/3/1159296843.geojson
+++ b/data/115/929/684/3/1159296843.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.330963,
     "geom:longitude":7.829052,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.330728,
     "lbl:longitude":7.806648,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578417,
         "eg:gisco_id":"NO_4223",
         "eurostat:nuts_2021_id":"4223",
-        "no-geonorge:kommunenum":4223
+        "no-geonorge:kommunenum":4223,
+        "no-geonorge:number":"4223"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595795,
     "wof:geomhash":"c886c07d695cb01379d5644ef5bc91b0",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"Vennesla",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/684/5/1159296845.geojson
+++ b/data/115/929/684/5/1159296845.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.373475,
     "geom:longitude":6.694538,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.39213,
     "lbl:longitude":6.704018,
     "lbl:max_zoom":18.0,
@@ -169,8 +178,10 @@
         "digitalenvoy:metro_code":578086,
         "eg:gisco_id":"NO_4207",
         "eurostat:nuts_2021_id":"4207",
-        "no-geonorge:kommunenum":4207
+        "no-geonorge:kommunenum":4207,
+        "no-geonorge:number":"4207"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595795,
     "wof:geomhash":"012591d77a454d0763edb9685b3609d3",
@@ -192,7 +203,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"Flekkefjord",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/685/1/1159296851.geojson
+++ b/data/115/929/685/1/1159296851.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.60662,
     "geom:longitude":10.792038,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.602478,
     "lbl:longitude":10.774379,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578097,
         "eg:gisco_id":"NO_5036",
         "eurostat:nuts_2021_id":"5036",
-        "no-geonorge:kommunenum":5036
+        "no-geonorge:kommunenum":5036,
+        "no-geonorge:number":"5036"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595796,
     "wof:geomhash":"c43110cfc93f7d2a1715590d63eb8a5e",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"Frosta",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/685/5/1159296855.geojson
+++ b/data/115/929/685/5/1159296855.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.679386,
     "geom:longitude":9.631746,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.689073,
     "lbl:longitude":9.605147,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578344,
         "eg:gisco_id":"NO_3449",
         "eurostat:nuts_2021_id":"3449",
-        "no-geonorge:kommunenum":3449
+        "no-geonorge:kommunenum":3449,
+        "no-geonorge:number":"3449"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595797,
     "wof:geomhash":"e5036bb3aa916f2545e170e532374bb0",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878848,
     "wof:name":"S\u00f8r-Aurdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/685/9/1159296859.geojson
+++ b/data/115/929/685/9/1159296859.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.750892,
     "geom:longitude":5.207966,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.789897,
     "lbl:longitude":5.222814,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578050,
         "eg:gisco_id":"NO_4613",
         "eurostat:nuts_2021_id":"4613",
-        "no-geonorge:kommunenum":4613
+        "no-geonorge:kommunenum":4613,
+        "no-geonorge:number":"4613"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595798,
     "wof:geomhash":"f7fbd0b5983cdde28ddcf99abe0401cb",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354076,
+    "wof:lastmodified":1695878849,
     "wof:name":"B\u00f8mlo",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/686/9/1159296869.geojson
+++ b/data/115/929/686/9/1159296869.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.37169,
     "geom:longitude":11.416587,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.362528,
     "lbl:longitude":11.433107,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578283,
         "eg:gisco_id":"NO_3016",
         "eurostat:nuts_2021_id":"3016",
-        "no-geonorge:kommunenum":3016
+        "no-geonorge:kommunenum":3016,
+        "no-geonorge:number":"3016"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595800,
     "wof:geomhash":"bcb2cba9182b8152609651618d77dcb3",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354077,
+    "wof:lastmodified":1695878849,
     "wof:name":"Rakkestad",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/687/1/1159296871.geojson
+++ b/data/115/929/687/1/1159296871.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.411035,
     "geom:longitude":25.138322,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.308278,
     "lbl:longitude":25.242258,
     "lbl:max_zoom":18.0,
@@ -178,8 +187,10 @@
         "digitalenvoy:metro_code":578164,
         "eg:gisco_id":"NO_5437",
         "eurostat:nuts_2021_id":"5437",
-        "no-geonorge:kommunenum":5437
+        "no-geonorge:kommunenum":5437,
+        "no-geonorge:number":"5437"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595801,
     "wof:geomhash":"ef9be6b36184f2fce1000ff5cdfe5427",
@@ -201,7 +212,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354077,
+    "wof:lastmodified":1695878849,
     "wof:name":"Karasjok",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/687/5/1159296875.geojson
+++ b/data/115/929/687/5/1159296875.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.758844,
     "geom:longitude":8.82417,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.753606,
     "lbl:longitude":8.800692,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578416,
         "eg:gisco_id":"NO_4212",
         "eurostat:nuts_2021_id":"4212",
-        "no-geonorge:kommunenum":4212
+        "no-geonorge:kommunenum":4212,
+        "no-geonorge:number":"4212"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595802,
     "wof:geomhash":"ebacdefe9a2e8ad0bdfc6de535de5611",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354077,
+    "wof:lastmodified":1695878849,
     "wof:name":"Veg\u00e5rshei",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/687/7/1159296877.geojson
+++ b/data/115/929/687/7/1159296877.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.853446,
     "geom:longitude":13.227952,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.924396,
     "lbl:longitude":13.373695,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578414,
         "eg:gisco_id":"NO_1824",
         "eurostat:nuts_2021_id":"1824",
-        "no-geonorge:kommunenum":1824
+        "no-geonorge:kommunenum":1824,
+        "no-geonorge:number":"1824"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595808,
     "wof:geomhash":"efe07bd607d1926919d3abb3e37deb30",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354077,
+    "wof:lastmodified":1695878849,
     "wof:name":"Vefsn",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/687/9/1159296879.geojson
+++ b/data/115/929/687/9/1159296879.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.673304,
     "geom:longitude":8.952647,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.62698,
     "lbl:longitude":8.959876,
     "lbl:max_zoom":18.0,
@@ -100,8 +109,10 @@
         "digitalenvoy:metro_code":578404,
         "eg:gisco_id":"NO_3435",
         "eurostat:nuts_2021_id":"3435",
-        "no-geonorge:kommunenum":3435
+        "no-geonorge:kommunenum":3435,
+        "no-geonorge:number":"3435"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595808,
     "wof:geomhash":"33bc5e50b32bef85fdea8ba8d3e42f99",
@@ -123,7 +134,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354077,
+    "wof:lastmodified":1695878850,
     "wof:name":"V\u00e5g\u00e5",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/688/1/1159296881.geojson
+++ b/data/115/929/688/1/1159296881.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.99635,
     "geom:longitude":12.062505,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.988767,
     "lbl:longitude":12.057002,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578065,
         "eg:gisco_id":"NO_3416",
         "eurostat:nuts_2021_id":"3416",
-        "no-geonorge:kommunenum":3416
+        "no-geonorge:kommunenum":3416,
+        "no-geonorge:number":"3416"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595809,
     "wof:geomhash":"31a946eb0ad8440ab4d09ee20dc65ceb",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354078,
+    "wof:lastmodified":1695878850,
     "wof:name":"Eidskog",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/688/3/1159296883.geojson
+++ b/data/115/929/688/3/1159296883.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.287382,
     "geom:longitude":14.568087,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.311622,
     "lbl:longitude":14.565932,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578405,
         "eg:gisco_id":"NO_1865",
         "eurostat:nuts_2021_id":"1865",
-        "no-geonorge:kommunenum":1865
+        "no-geonorge:kommunenum":1865,
+        "no-geonorge:number":"1865"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595809,
     "wof:geomhash":"b3c57982c0c0033c1c7d2f9c681b3f53",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354078,
+    "wof:lastmodified":1695878850,
     "wof:name":"V\u00e5gan",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/688/7/1159296887.geojson
+++ b/data/115/929/688/7/1159296887.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.111215,
     "geom:longitude":4.859666,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.122555,
     "lbl:longitude":4.873459,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578340,
         "eg:gisco_id":"NO_4636",
         "eurostat:nuts_2021_id":"4636",
-        "no-geonorge:kommunenum":4636
+        "no-geonorge:kommunenum":4636,
+        "no-geonorge:number":"4636"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595810,
     "wof:geomhash":"e67696177c263f69464fdf67953513e9",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354078,
+    "wof:lastmodified":1695878851,
     "wof:name":"Solund",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/688/9/1159296889.geojson
+++ b/data/115/929/688/9/1159296889.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.428592,
     "geom:longitude":10.869446,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.38389,
     "lbl:longitude":10.930995,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578085,
         "eg:gisco_id":"NO_5049",
         "eurostat:nuts_2021_id":"5049",
-        "no-geonorge:kommunenum":5049
+        "no-geonorge:kommunenum":5049,
+        "no-geonorge:number":"5049"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595810,
     "wof:geomhash":"adb30c65ae193d899b0e04bb4262587d",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354079,
+    "wof:lastmodified":1695878851,
     "wof:name":"Flatanger",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/689/1/1159296891.geojson
+++ b/data/115/929/689/1/1159296891.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.06769,
     "geom:longitude":10.507818,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.101223,
     "lbl:longitude":10.501699,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578007,
         "eg:gisco_id":"NO_3428",
         "eurostat:nuts_2021_id":"3428",
-        "no-geonorge:kommunenum":3428
+        "no-geonorge:kommunenum":3428,
+        "no-geonorge:number":"3428"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595810,
     "wof:geomhash":"9f439b63f4de890d55a1b30c902fd59e",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354079,
+    "wof:lastmodified":1695878851,
     "wof:name":"Alvdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/689/3/1159296893.geojson
+++ b/data/115/929/689/3/1159296893.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.984617,
     "geom:longitude":23.248098,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.924202,
     "lbl:longitude":23.71121,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578006,
         "eg:gisco_id":"NO_5403",
         "eurostat:nuts_2021_id":"5403",
-        "no-geonorge:kommunenum":5403
+        "no-geonorge:kommunenum":5403,
+        "no-geonorge:number":"5403"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595811,
     "wof:geomhash":"8d2efe3dd23bc940b6e744a6f3db2ba6",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354079,
+    "wof:lastmodified":1695878851,
     "wof:name":"Alta",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/689/9/1159296899.geojson
+++ b/data/115/929/689/9/1159296899.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.561761,
     "geom:longitude":22.477019,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.601166,
     "lbl:longitude":22.464585,
     "lbl:max_zoom":18.0,
@@ -169,8 +178,10 @@
         "digitalenvoy:metro_code":578133,
         "eg:gisco_id":"NO_5433",
         "eurostat:nuts_2021_id":"5433",
-        "no-geonorge:kommunenum":5433
+        "no-geonorge:kommunenum":5433,
+        "no-geonorge:number":"5433"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595812,
     "wof:geomhash":"893dcc1a9a17b038a9ddba41f5d9a3a4",
@@ -192,7 +203,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354079,
+    "wof:lastmodified":1695878852,
     "wof:name":"Hasvik",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/690/9/1159296909.geojson
+++ b/data/115/929/690/9/1159296909.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.11144,
     "geom:longitude":12.579297,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.095408,
     "lbl:longitude":12.792801,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578232,
         "eg:gisco_id":"NO_1811",
         "eurostat:nuts_2021_id":"1811",
-        "no-geonorge:kommunenum":1811
+        "no-geonorge:kommunenum":1811,
+        "no-geonorge:number":"1811"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595815,
     "wof:geomhash":"968ba000ee1cae8f43710320af9841c9",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354080,
+    "wof:lastmodified":1695878852,
     "wof:name":"Bindal",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/691/7/1159296917.geojson
+++ b/data/115/929/691/7/1159296917.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.831664,
     "geom:longitude":17.164215,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.873331,
     "lbl:longitude":17.350968,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578158,
         "eg:gisco_id":"NO_5413",
         "eurostat:nuts_2021_id":"5413",
-        "no-geonorge:kommunenum":5413
+        "no-geonorge:kommunenum":5413,
+        "no-geonorge:number":"5413"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595816,
     "wof:geomhash":"d54e30d0699b9d3374a3d5c324109140",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354080,
+    "wof:lastmodified":1695878852,
     "wof:name":"Ibestad",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/691/9/1159296919.geojson
+++ b/data/115/929/691/9/1159296919.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.546943,
     "geom:longitude":5.799509,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.536624,
     "lbl:longitude":5.704398,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578428,
         "eg:gisco_id":"NO_1160",
         "eurostat:nuts_2021_id":"1160",
-        "no-geonorge:kommunenum":1160
+        "no-geonorge:kommunenum":1160,
+        "no-geonorge:number":"1160"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595817,
     "wof:geomhash":"9b816b5d11ea94d633334fe07f888b7d",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354080,
+    "wof:lastmodified":1695878853,
     "wof:name":"Vindafjord",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/692/3/1159296923.geojson
+++ b/data/115/929/692/3/1159296923.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.742528,
     "geom:longitude":9.152355,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.77923,
     "lbl:longitude":9.16311,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578295,
         "eg:gisco_id":"NO_4201",
         "eurostat:nuts_2021_id":"4201",
-        "no-geonorge:kommunenum":4201
+        "no-geonorge:kommunenum":4201,
+        "no-geonorge:number":"4201"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595818,
     "wof:geomhash":"b06b688949d509d6305c9795040eb432",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354080,
+    "wof:lastmodified":1695878853,
     "wof:name":"Ris\u00f8r",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/692/9/1159296929.geojson
+++ b/data/115/929/692/9/1159296929.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.51326,
     "geom:longitude":6.979632,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.578573,
     "lbl:longitude":6.956682,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578180,
         "eg:gisco_id":"NO_4227",
         "eurostat:nuts_2021_id":"4227",
-        "no-geonorge:kommunenum":4227
+        "no-geonorge:kommunenum":4227,
+        "no-geonorge:number":"4227"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595820,
     "wof:geomhash":"a9f020e2877a168f824c26208fcfb2e5",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354080,
+    "wof:lastmodified":1695878853,
     "wof:name":"Kvinesdal",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/693/3/1159296933.geojson
+++ b/data/115/929/693/3/1159296933.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.03219,
     "geom:longitude":9.29263,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.053202,
     "lbl:longitude":9.297134,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578291,
         "eg:gisco_id":"NO_5061",
         "eurostat:nuts_2021_id":"5061",
-        "no-geonorge:kommunenum":5061
+        "no-geonorge:kommunenum":5061,
+        "no-geonorge:number":"5061"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595821,
     "wof:geomhash":"cdfcf3c90d33c92721455fdbb1aeafcc",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354081,
+    "wof:lastmodified":1695878853,
     "wof:name":"Rindal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/693/5/1159296935.geojson
+++ b/data/115/929/693/5/1159296935.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.274381,
     "geom:longitude":9.125314,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.294797,
     "lbl:longitude":9.072563,
     "lbl:max_zoom":18.0,
@@ -112,8 +121,10 @@
         "digitalenvoy:metro_code":578248,
         "eg:gisco_id":"NO_3816",
         "eurostat:nuts_2021_id":"3816",
-        "no-geonorge:kommunenum":3816
+        "no-geonorge:kommunenum":3816,
+        "no-geonorge:number":"3816"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595821,
     "wof:geomhash":"b3e6c9a41f49a2ff8b0c9246372237cd",
@@ -135,7 +146,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354081,
+    "wof:lastmodified":1695878853,
     "wof:name":"Nome",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/693/7/1159296937.geojson
+++ b/data/115/929/693/7/1159296937.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.862528,
     "geom:longitude":10.233704,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.856438,
     "lbl:longitude":10.233651,
     "lbl:max_zoom":18.0,
@@ -109,8 +118,10 @@
         "digitalenvoy:metro_code":578196,
         "eg:gisco_id":"NO_3049",
         "eurostat:nuts_2021_id":"3049",
-        "no-geonorge:kommunenum":3049
+        "no-geonorge:kommunenum":3049,
+        "no-geonorge:number":"3049"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595822,
     "wof:geomhash":"428920174b2527368f3ff3e0be705e0f",
@@ -132,7 +143,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354081,
+    "wof:lastmodified":1695878853,
     "wof:name":"Lier",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/694/1/1159296941.geojson
+++ b/data/115/929/694/1/1159296941.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.08081,
     "geom:longitude":11.013044,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.071613,
     "lbl:longitude":11.014988,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578108,
         "eg:gisco_id":"NO_3032",
         "eurostat:nuts_2021_id":"3032",
-        "no-geonorge:kommunenum":3032
+        "no-geonorge:kommunenum":3032,
+        "no-geonorge:number":"3032"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595824,
     "wof:geomhash":"d10f7286adb5dfd3c802fffb04fc3afc",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354081,
+    "wof:lastmodified":1695878854,
     "wof:name":"Gjerdrum",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/694/7/1159296947.geojson
+++ b/data/115/929/694/7/1159296947.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.627882,
     "geom:longitude":29.622252,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.564227,
     "lbl:longitude":29.720778,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578351,
         "eg:gisco_id":"NO_5444",
         "eurostat:nuts_2021_id":"5444",
-        "no-geonorge:kommunenum":5444
+        "no-geonorge:kommunenum":5444,
+        "no-geonorge:number":"5444"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595825,
     "wof:geomhash":"0a841faa2da74364c1f20b6ebb3a75d6",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878854,
     "wof:name":"S\u00f8r-Varanger",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/694/9/1159296949.geojson
+++ b/data/115/929/694/9/1159296949.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.974712,
     "geom:longitude":6.071167,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.97514,
     "lbl:longitude":6.119485,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578181,
         "eg:gisco_id":"NO_4617",
         "eurostat:nuts_2021_id":"4617",
-        "no-geonorge:kommunenum":4617
+        "no-geonorge:kommunenum":4617,
+        "no-geonorge:number":"4617"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595826,
     "wof:geomhash":"1bc9202e7b2e2ffd260f1829300971d1",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878855,
     "wof:name":"Kvinnherad",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/695/1/1159296951.geojson
+++ b/data/115/929/695/1/1159296951.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.509824,
     "geom:longitude":16.966131,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.520042,
     "lbl:longitude":16.862821,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578073,
         "eg:gisco_id":"NO_1853",
         "eurostat:nuts_2021_id":"1853",
-        "no-geonorge:kommunenum":1853
+        "no-geonorge:kommunenum":1853,
+        "no-geonorge:number":"1853"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595826,
     "wof:geomhash":"67b8e0f3a1ae11afa8e7009dc89a9d30",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878855,
     "wof:name":"Evenes",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/695/3/1159296953.geojson
+++ b/data/115/929/695/3/1159296953.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.210989,
     "geom:longitude":5.432358,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.209858,
     "lbl:longitude":5.420298,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578049,
         "eg:gisco_id":"NO_1145",
         "eurostat:nuts_2021_id":"1145",
-        "no-geonorge:kommunenum":1145
+        "no-geonorge:kommunenum":1145,
+        "no-geonorge:number":"1145"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595826,
     "wof:geomhash":"da4283e8c052be85a42f15387fb23a22",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878855,
     "wof:name":"Bokn",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/695/5/1159296955.geojson
+++ b/data/115/929/695/5/1159296955.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.599316,
     "geom:longitude":5.738194,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.604867,
     "lbl:longitude":5.708239,
     "lbl:max_zoom":18.0,
@@ -76,8 +85,10 @@
         "digitalenvoy:metro_code":578122,
         "eg:gisco_id":"NO_1119",
         "eurostat:nuts_2021_id":"1119",
-        "no-geonorge:kommunenum":1119
+        "no-geonorge:kommunenum":1119,
+        "no-geonorge:number":"1119"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595827,
     "wof:geomhash":"e87653a9a1c0cd67ab9d0eba8ea94723",
@@ -99,7 +110,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878855,
     "wof:name":"H\u00e5",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/695/9/1159296959.geojson
+++ b/data/115/929/695/9/1159296959.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.511843,
     "geom:longitude":15.788241,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.439823,
     "lbl:longitude":15.911989,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578345,
         "eg:gisco_id":"NO_1845",
         "eurostat:nuts_2021_id":"1845",
-        "no-geonorge:kommunenum":1845
+        "no-geonorge:kommunenum":1845,
+        "no-geonorge:number":"1845"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595827,
     "wof:geomhash":"41da71e391396ea92313d9681cec3f24",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354082,
+    "wof:lastmodified":1695878855,
     "wof:name":"S\u00f8rfold",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/696/1/1159296961.geojson
+++ b/data/115/929/696/1/1159296961.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.222732,
     "geom:longitude":6.451525,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.199255,
     "lbl:longitude":6.45243,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578143,
         "eg:gisco_id":"NO_1133",
         "eurostat:nuts_2021_id":"1133",
-        "no-geonorge:kommunenum":1133
+        "no-geonorge:kommunenum":1133,
+        "no-geonorge:number":"1133"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595828,
     "wof:geomhash":"08b9929665e70c2814ac9cc4dedde46e",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354083,
+    "wof:lastmodified":1695878855,
     "wof:name":"Hjelmeland",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/696/3/1159296963.geojson
+++ b/data/115/929/696/3/1159296963.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.414761,
     "geom:longitude":14.510817,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.416991,
     "lbl:longitude":14.590361,
     "lbl:max_zoom":18.0,
@@ -118,8 +127,10 @@
         "digitalenvoy:metro_code":578284,
         "eg:gisco_id":"NO_1833",
         "eurostat:nuts_2021_id":"1833",
-        "no-geonorge:kommunenum":1833
+        "no-geonorge:kommunenum":1833,
+        "no-geonorge:number":"1833"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595828,
     "wof:geomhash":"c94c175c9cdedb2252449986af68e9e3",
@@ -141,7 +152,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354083,
+    "wof:lastmodified":1695878855,
     "wof:name":"Rana",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/696/5/1159296965.geojson
+++ b/data/115/929/696/5/1159296965.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.566059,
     "geom:longitude":8.534288,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.661674,
     "lbl:longitude":8.380807,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578320,
         "eg:gisco_id":"NO_3820",
         "eurostat:nuts_2021_id":"3820",
-        "no-geonorge:kommunenum":3820
+        "no-geonorge:kommunenum":3820,
+        "no-geonorge:number":"3820"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595829,
     "wof:geomhash":"91362074c6c00996f5f955898eb49bfd",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354083,
+    "wof:lastmodified":1695878856,
     "wof:name":"Seljord",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/696/7/1159296967.geojson
+++ b/data/115/929/696/7/1159296967.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.849916,
     "geom:longitude":6.917917,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.826445,
     "lbl:longitude":7.005664,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578365,
         "eg:gisco_id":"NO_4651",
         "eurostat:nuts_2021_id":"4651",
-        "no-geonorge:kommunenum":4651
+        "no-geonorge:kommunenum":4651,
+        "no-geonorge:number":"4651"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595829,
     "wof:geomhash":"3a139bdaae1d4e87d882e6e90f34bdf9",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354083,
+    "wof:lastmodified":1695878856,
     "wof:name":"Stryn",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/696/9/1159296969.geojson
+++ b/data/115/929/696/9/1159296969.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.083623,
     "geom:longitude":10.853224,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.105668,
     "lbl:longitude":10.85322,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578247,
         "eg:gisco_id":"NO_3031",
         "eurostat:nuts_2021_id":"3031",
-        "no-geonorge:kommunenum":3031
+        "no-geonorge:kommunenum":3031,
+        "no-geonorge:number":"3031"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595830,
     "wof:geomhash":"9996dbfe4057c3b5d59702f210fb4f79",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354083,
+    "wof:lastmodified":1695878856,
     "wof:name":"Nittedal",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/697/1/1159296971.geojson
+++ b/data/115/929/697/1/1159296971.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.557527,
     "geom:longitude":10.319316,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.545074,
     "lbl:longitude":10.281055,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578292,
         "eg:gisco_id":"NO_3439",
         "eurostat:nuts_2021_id":"3439",
-        "no-geonorge:kommunenum":3439
+        "no-geonorge:kommunenum":3439,
+        "no-geonorge:number":"3439"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595836,
     "wof:geomhash":"979d603644401048e6b15a93dd26cbda",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878856,
     "wof:name":"Ringebu",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/697/3/1159296973.geojson
+++ b/data/115/929/697/3/1159296973.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.214718,
     "geom:longitude":11.69682,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.221556,
     "lbl:longitude":11.694139,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578013,
         "eg:gisco_id":"NO_3012",
         "eurostat:nuts_2021_id":"3012",
-        "no-geonorge:kommunenum":3012
+        "no-geonorge:kommunenum":3012,
+        "no-geonorge:number":"3012"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595836,
     "wof:geomhash":"d17feb68ae9eb50e4d1737064a984de7",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878856,
     "wof:name":"Aremark",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/697/7/1159296977.geojson
+++ b/data/115/929/697/7/1159296977.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.200241,
     "geom:longitude":11.137111,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.201524,
     "lbl:longitude":11.137056,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578318,
         "eg:gisco_id":"NO_5032",
         "eurostat:nuts_2021_id":"5032",
-        "no-geonorge:kommunenum":5032
+        "no-geonorge:kommunenum":5032,
+        "no-geonorge:number":"5032"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595837,
     "wof:geomhash":"9dd8b0f941103c04f85cf3c0b4690d37",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878857,
     "wof:name":"Selbu",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/697/9/1159296979.geojson
+++ b/data/115/929/697/9/1159296979.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.974973,
     "geom:longitude":9.640009,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.958374,
     "lbl:longitude":9.654824,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578072,
         "eg:gisco_id":"NO_3450",
         "eurostat:nuts_2021_id":"3450",
-        "no-geonorge:kommunenum":3450
+        "no-geonorge:kommunenum":3450,
+        "no-geonorge:number":"3450"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595837,
     "wof:geomhash":"8233faeadaa512b3c718015fe752c55a",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878857,
     "wof:name":"Etnedal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/698/1/1159296981.geojson
+++ b/data/115/929/698/1/1159296981.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.889155,
     "geom:longitude":5.932516,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.920783,
     "lbl:longitude":5.974946,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578227,
         "eg:gisco_id":"NO_4629",
         "eurostat:nuts_2021_id":"4629",
-        "no-geonorge:kommunenum":4629
+        "no-geonorge:kommunenum":4629,
+        "no-geonorge:number":"4629"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595838,
     "wof:geomhash":"780981774edf4a8143d449f9061f6c5f",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878857,
     "wof:name":"Modalen",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/698/3/1159296983.geojson
+++ b/data/115/929/698/3/1159296983.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.851493,
     "geom:longitude":11.246469,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.855476,
     "lbl:longitude":11.169642,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578149,
         "eg:gisco_id":"NO_5026",
         "eurostat:nuts_2021_id":"5026",
-        "no-geonorge:kommunenum":5026
+        "no-geonorge:kommunenum":5026,
+        "no-geonorge:number":"5026"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595839,
     "wof:geomhash":"91511acee828aa2c65cd55b9c614e0c6",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354084,
+    "wof:lastmodified":1695878857,
     "wof:name":"Holt\u00e5len",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/699/1/1159296991.geojson
+++ b/data/115/929/699/1/1159296991.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.100181,
     "geom:longitude":8.977938,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.123996,
     "lbl:longitude":8.909861,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578059,
         "eg:gisco_id":"NO_3815",
         "eurostat:nuts_2021_id":"3815",
-        "no-geonorge:kommunenum":3815
+        "no-geonorge:kommunenum":3815,
+        "no-geonorge:number":"3815"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595841,
     "wof:geomhash":"0b460bd369e900276202a97c74ec0022",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354085,
+    "wof:lastmodified":1695878857,
     "wof:name":"Drangedal",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/699/7/1159296997.geojson
+++ b/data/115/929/699/7/1159296997.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.972893,
     "geom:longitude":14.114248,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.883788,
     "lbl:longitude":14.223039,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578105,
         "eg:gisco_id":"NO_1838",
         "eurostat:nuts_2021_id":"1838",
-        "no-geonorge:kommunenum":1838
+        "no-geonorge:kommunenum":1838,
+        "no-geonorge:number":"1838"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595841,
     "wof:geomhash":"62ac1beb26215d4f7db7dcbac3f02641",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354085,
+    "wof:lastmodified":1695878857,
     "wof:name":"Gildesk\u00e5l",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/700/5/1159297005.geojson
+++ b/data/115/929/700/5/1159297005.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.275903,
     "geom:longitude":5.268091,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.216868,
     "lbl:longitude":5.253357,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578166,
         "eg:gisco_id":"NO_1149",
         "eurostat:nuts_2021_id":"1149",
-        "no-geonorge:kommunenum":1149
+        "no-geonorge:kommunenum":1149,
+        "no-geonorge:number":"1149"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595844,
     "wof:geomhash":"456cb79d246afc7d08b5d7c0483ea7ef",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354085,
+    "wof:lastmodified":1695878858,
     "wof:name":"Karm\u00f8y",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/700/7/1159297007.geojson
+++ b/data/115/929/700/7/1159297007.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.908632,
     "geom:longitude":12.499793,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.953551,
     "lbl:longitude":12.553362,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578005,
         "eg:gisco_id":"NO_1820",
         "eurostat:nuts_2021_id":"1820",
-        "no-geonorge:kommunenum":1820
+        "no-geonorge:kommunenum":1820,
+        "no-geonorge:number":"1820"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595844,
     "wof:geomhash":"331961df8ca7bf6331ade1f6bff3320e",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354085,
+    "wof:lastmodified":1695878858,
     "wof:name":"Alstahaug",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/700/9/1159297009.geojson
+++ b/data/115/929/700/9/1159297009.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.941428,
     "geom:longitude":10.495133,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.941252,
     "lbl:longitude":10.491374,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578030,
         "eg:gisco_id":"NO_3024",
         "eurostat:nuts_2021_id":"3024",
-        "no-geonorge:kommunenum":3024
+        "no-geonorge:kommunenum":3024,
+        "no-geonorge:number":"3024"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595845,
     "wof:geomhash":"9bc7743b3bac94bb0d8e4cd738d3be76",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878858,
     "wof:name":"B\u00e6rum",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/701/3/1159297013.geojson
+++ b/data/115/929/701/3/1159297013.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.07891,
     "geom:longitude":9.458614,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.084065,
     "lbl:longitude":9.427226,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578057,
         "eg:gisco_id":"NO_3431",
         "eurostat:nuts_2021_id":"3431",
-        "no-geonorge:kommunenum":3431
+        "no-geonorge:kommunenum":3431,
+        "no-geonorge:number":"3431"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595845,
     "wof:geomhash":"87df64257bbbc8dc5650576f914d0a78",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878858,
     "wof:name":"Dovre",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/701/5/1159297015.geojson
+++ b/data/115/929/701/5/1159297015.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.354809,
     "geom:longitude":5.984693,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.350713,
     "lbl:longitude":5.984754,
     "lbl:max_zoom":18.0,
@@ -151,13 +160,15 @@
         "digitalenvoy:metro_code":578313,
         "eg:gisco_id":"NO_1517",
         "eurostat:nuts_2021_id":"1517",
-        "no-geonorge:kommunenum":1517
+        "no-geonorge:kommunenum":1517,
+        "no-geonorge:number":"1517"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578131
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595845,
     "wof:geomhash":"5bda54bac0a124452b6e6927a6547d2f",
@@ -179,7 +190,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878858,
     "wof:name":"Hareid",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/702/1/1159297021.geojson
+++ b/data/115/929/702/1/1159297021.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.541454,
     "geom:longitude":9.539837,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.537702,
     "lbl:longitude":9.528439,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578261,
         "eg:gisco_id":"NO_5021",
         "eurostat:nuts_2021_id":"5021",
-        "no-geonorge:kommunenum":5021
+        "no-geonorge:kommunenum":5021,
+        "no-geonorge:number":"5021"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595846,
     "wof:geomhash":"58694e95103941a38624b95116395246",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878858,
     "wof:name":"Oppdal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/702/7/1159297027.geojson
+++ b/data/115/929/702/7/1159297027.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.306751,
     "geom:longitude":4.884643,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.306551,
     "lbl:longitude":4.875408,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578401,
         "eg:gisco_id":"NO_1151",
         "eurostat:nuts_2021_id":"1151",
-        "no-geonorge:kommunenum":1151
+        "no-geonorge:kommunenum":1151,
+        "no-geonorge:number":"1151"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595848,
     "wof:geomhash":"202aa540e52f89f14c7c6687e0f16f90",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878859,
     "wof:name":"Utsira",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/703/3/1159297033.geojson
+++ b/data/115/929/703/3/1159297033.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.58337,
     "geom:longitude":9.522912,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.615157,
     "lbl:longitude":9.670924,
     "lbl:max_zoom":18.0,
@@ -157,13 +166,15 @@
         "digitalenvoy:metro_code":578251,
         "eg:gisco_id":"NO_3436",
         "eurostat:nuts_2021_id":"3436",
-        "no-geonorge:kommunenum":3436
+        "no-geonorge:kommunenum":3436,
+        "no-geonorge:number":"3436"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578346
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595850,
     "wof:geomhash":"b87c694ea1b855e282884f6f6c0b8408",
@@ -185,7 +196,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878859,
     "wof:name":"Nord-Fron",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/703/5/1159297035.geojson
+++ b/data/115/929/703/5/1159297035.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.255467,
     "geom:longitude":9.486153,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.23209,
     "lbl:longitude":9.535382,
     "lbl:max_zoom":18.0,
@@ -223,8 +232,10 @@
         "digitalenvoy:metro_code":578328,
         "eg:gisco_id":"NO_3807",
         "eurostat:nuts_2021_id":"3807",
-        "no-geonorge:kommunenum":3807
+        "no-geonorge:kommunenum":3807,
+        "no-geonorge:number":"3807"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595850,
     "wof:geomhash":"97e0fefe92423f7f3cce26f78e290d64",
@@ -246,7 +257,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878859,
     "wof:name":"Skien",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/703/7/1159297037.geojson
+++ b/data/115/929/703/7/1159297037.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.650256,
     "geom:longitude":12.167631,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.704181,
     "lbl:longitude":12.247364,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578021,
         "eg:gisco_id":"NO_3418",
         "eurostat:nuts_2021_id":"3418",
-        "no-geonorge:kommunenum":3418
+        "no-geonorge:kommunenum":3418,
+        "no-geonorge:number":"3418"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595852,
     "wof:geomhash":"681f7df901b8f13d4701189882dc2c1b",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354086,
+    "wof:lastmodified":1695878859,
     "wof:name":"\u00c5snes",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/703/9/1159297039.geojson
+++ b/data/115/929/703/9/1159297039.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.212773,
     "geom:longitude":13.774038,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.213549,
     "lbl:longitude":13.720627,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578424,
         "eg:gisco_id":"NO_1860",
         "eurostat:nuts_2021_id":"1860",
-        "no-geonorge:kommunenum":1860
+        "no-geonorge:kommunenum":1860,
+        "no-geonorge:number":"1860"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595853,
     "wof:geomhash":"a34183786732b3455c6c3bb370537c74",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354087,
+    "wof:lastmodified":1695878860,
     "wof:name":"Vestv\u00e5g\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/704/1/1159297041.geojson
+++ b/data/115/929/704/1/1159297041.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.400498,
     "geom:longitude":10.53915,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.493469,
     "lbl:longitude":10.327828,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578392,
         "eg:gisco_id":"NO_3427",
         "eurostat:nuts_2021_id":"3427",
-        "no-geonorge:kommunenum":3427
+        "no-geonorge:kommunenum":3427,
+        "no-geonorge:number":"3427"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595854,
     "wof:geomhash":"4ec704296571fbdb652e38118db7da98",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354087,
+    "wof:lastmodified":1695878860,
     "wof:name":"Tynset",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/704/3/1159297043.geojson
+++ b/data/115/929/704/3/1159297043.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.133921,
     "geom:longitude":23.550623,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.201268,
     "lbl:longitude":23.434471,
     "lbl:max_zoom":18.0,
@@ -202,8 +211,10 @@
         "digitalenvoy:metro_code":578167,
         "eg:gisco_id":"NO_5430",
         "eurostat:nuts_2021_id":"5430",
-        "no-geonorge:kommunenum":5430
+        "no-geonorge:kommunenum":5430,
+        "no-geonorge:number":"5430"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595855,
     "wof:geomhash":"9a3a866e7ea35b2e8236901c14324511",
@@ -225,7 +236,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878860,
     "wof:name":"Kautokeino",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/704/9/1159297049.geojson
+++ b/data/115/929/704/9/1159297049.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.901514,
     "geom:longitude":13.639211,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.950157,
     "lbl:longitude":13.683162,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578304,
         "eg:gisco_id":"NO_5043",
         "eurostat:nuts_2021_id":"5043",
-        "no-geonorge:kommunenum":5043
+        "no-geonorge:kommunenum":5043,
+        "no-geonorge:number":"5043"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595856,
     "wof:geomhash":"11f0951e614129c798b8b3bb262b3339",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878861,
     "wof:name":"R\u00f8yrvik",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/705/1/1159297051.geojson
+++ b/data/115/929/705/1/1159297051.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.282998,
     "geom:longitude":5.41584,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.289777,
     "lbl:longitude":5.453478,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578081,
         "eg:gisco_id":"NO_4646",
         "eurostat:nuts_2021_id":"4646",
-        "no-geonorge:kommunenum":4646
+        "no-geonorge:kommunenum":4646,
+        "no-geonorge:number":"4646"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595857,
     "wof:geomhash":"c9f02d90f4a3641957891f9f761ebf74",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878861,
     "wof:name":"Fjaler",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/705/5/1159297055.geojson
+++ b/data/115/929/705/5/1159297055.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.092493,
     "geom:longitude":18.167544,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.069134,
     "lbl:longitude":18.172889,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578348,
         "eg:gisco_id":"NO_5419",
         "eurostat:nuts_2021_id":"5419",
-        "no-geonorge:kommunenum":5419
+        "no-geonorge:kommunenum":5419,
+        "no-geonorge:number":"5419"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595857,
     "wof:geomhash":"474856ef1bb7dd8e471cbc28569d10cc",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878861,
     "wof:name":"S\u00f8rreisa",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/705/9/1159297059.geojson
+++ b/data/115/929/705/9/1159297059.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.640122,
     "geom:longitude":12.701818,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.604752,
     "lbl:longitude":12.863077,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578425,
         "eg:gisco_id":"NO_1816",
         "eurostat:nuts_2021_id":"1816",
-        "no-geonorge:kommunenum":1816
+        "no-geonorge:kommunenum":1816,
+        "no-geonorge:number":"1816"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595859,
     "wof:geomhash":"62bae51e15179d2fd115790e1bdcc9c4",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878861,
     "wof:name":"Vevelstad",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/706/1/1159297061.geojson
+++ b/data/115/929/706/1/1159297061.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.255245,
     "geom:longitude":11.500083,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.284684,
     "lbl:longitude":11.532617,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578009,
         "eg:gisco_id":"NO_3422",
         "eurostat:nuts_2021_id":"3422",
-        "no-geonorge:kommunenum":3422
+        "no-geonorge:kommunenum":3422,
+        "no-geonorge:number":"3422"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595860,
     "wof:geomhash":"49cb8ec6f5767af35798200bc6e9f6eb",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354088,
+    "wof:lastmodified":1695878861,
     "wof:name":"\u00c5mot",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/706/3/1159297063.geojson
+++ b/data/115/929/706/3/1159297063.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.490204,
     "geom:longitude":6.472198,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.526638,
     "lbl:longitude":6.505721,
     "lbl:max_zoom":18.0,
@@ -295,8 +304,10 @@
         "digitalenvoy:metro_code":578207,
         "eg:gisco_id":"NO_1112",
         "eurostat:nuts_2021_id":"1112",
-        "no-geonorge:kommunenum":1112
+        "no-geonorge:kommunenum":1112,
+        "no-geonorge:number":"1112"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595860,
     "wof:geomhash":"ce597a8a4d8e7c77e53a60d1334d1e79",
@@ -318,7 +329,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878861,
     "wof:name":"Lund",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/706/7/1159297067.geojson
+++ b/data/115/929/706/7/1159297067.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.455938,
     "geom:longitude":11.904254,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.448918,
     "lbl:longitude":11.899502,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578273,
         "eg:gisco_id":"NO_5047",
         "eurostat:nuts_2021_id":"5047",
-        "no-geonorge:kommunenum":5047
+        "no-geonorge:kommunenum":5047,
+        "no-geonorge:number":"5047"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595861,
     "wof:geomhash":"cd5599ea770fbb34a45277042b36a8ef",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878861,
     "wof:name":"Overhalla",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/706/9/1159297069.geojson
+++ b/data/115/929/706/9/1159297069.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.198018,
     "geom:longitude":9.66757,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.211402,
     "lbl:longitude":9.65046,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578175,
         "eg:gisco_id":"NO_3046",
         "eurostat:nuts_2021_id":"3046",
-        "no-geonorge:kommunenum":3046
+        "no-geonorge:kommunenum":3046,
+        "no-geonorge:number":"3046"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595861,
     "wof:geomhash":"cfad8b99f1134f10bc4076966ae754e1",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878861,
     "wof:name":"Kr\u00f8dsherad",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/707/1/1159297071.geojson
+++ b/data/115/929/707/1/1159297071.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.167338,
     "geom:longitude":10.420371,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.208653,
     "lbl:longitude":10.410594,
     "lbl:max_zoom":18.0,
@@ -61,13 +70,15 @@
         "digitalenvoy:metro_code":578258,
         "eg:gisco_id":"NO_3811",
         "eurostat:nuts_2021_id":"3811",
-        "no-geonorge:kommunenum":3811
+        "no-geonorge:kommunenum":3811,
+        "no-geonorge:number":"3811"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578379
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595862,
     "wof:geomhash":"a1b14bd79fe1c0af016dfd81842b328d",
@@ -89,7 +100,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878862,
     "wof:name":"F\u00e6rder",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/707/3/1159297073.geojson
+++ b/data/115/929/707/3/1159297073.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.233776,
     "geom:longitude":10.961818,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.240629,
     "lbl:longitude":10.958405,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578236,
         "eg:gisco_id":"NO_3036",
         "eurostat:nuts_2021_id":"3036",
-        "no-geonorge:kommunenum":3036
+        "no-geonorge:kommunenum":3036,
+        "no-geonorge:number":"3036"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595862,
     "wof:geomhash":"b7e6866253932c3d45e6cd056586e8d0",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878862,
     "wof:name":"Nannestad",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/707/5/1159297075.geojson
+++ b/data/115/929/707/5/1159297075.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.374304,
     "geom:longitude":8.48942,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.388853,
     "lbl:longitude":8.452869,
     "lbl:max_zoom":18.0,
@@ -193,8 +202,10 @@
         "digitalenvoy:metro_code":578118,
         "eg:gisco_id":"NO_4202",
         "eurostat:nuts_2021_id":"4202",
-        "no-geonorge:kommunenum":4202
+        "no-geonorge:kommunenum":4202,
+        "no-geonorge:number":"4202"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595863,
     "wof:geomhash":"0e3388c93b9d1eb8cee6ef93ceb1e1a0",
@@ -216,7 +227,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354089,
+    "wof:lastmodified":1695878862,
     "wof:name":"Grimstad",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/707/9/1159297079.geojson
+++ b/data/115/929/707/9/1159297079.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.161376,
     "geom:longitude":8.055362,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.152918,
     "lbl:longitude":8.048657,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578100,
         "eg:gisco_id":"NO_3823",
         "eurostat:nuts_2021_id":"3823",
-        "no-geonorge:kommunenum":3823
+        "no-geonorge:kommunenum":3823,
+        "no-geonorge:number":"3823"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595864,
     "wof:geomhash":"0fee2ce9517e43265b91da392d31f3ea",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878862,
     "wof:name":"Fyresdal",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/708/1/1159297081.geojson
+++ b/data/115/929/708/1/1159297081.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.673381,
     "geom:longitude":12.663004,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.668509,
     "lbl:longitude":12.638647,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578403,
         "eg:gisco_id":"NO_1857",
         "eurostat:nuts_2021_id":"1857",
-        "no-geonorge:kommunenum":1857
+        "no-geonorge:kommunenum":1857,
+        "no-geonorge:number":"1857"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595865,
     "wof:geomhash":"ef2abad4129363cc8405984b2de2ad9b",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878862,
     "wof:name":"V\u00e6r\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/708/9/1159297089.geojson
+++ b/data/115/929/708/9/1159297089.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.950841,
     "geom:longitude":11.14287,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.954592,
     "lbl:longitude":11.153049,
     "lbl:max_zoom":18.0,
@@ -91,8 +100,10 @@
         "digitalenvoy:metro_code":578127,
         "eg:gisco_id":"NO_3403",
         "eurostat:nuts_2021_id":"3403",
-        "no-geonorge:kommunenum":3403
+        "no-geonorge:kommunenum":3403,
+        "no-geonorge:number":"3403"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595866,
     "wof:geomhash":"19b1e246a80171cc48b19a5d87fd4a8a",
@@ -114,7 +125,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878862,
     "wof:name":"Hamar",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/709/1/1159297091.geojson
+++ b/data/115/929/709/1/1159297091.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.051004,
     "geom:longitude":5.183799,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.032528,
     "lbl:longitude":5.266713,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578027,
         "eg:gisco_id":"NO_4625",
         "eurostat:nuts_2021_id":"4625",
-        "no-geonorge:kommunenum":4625
+        "no-geonorge:kommunenum":4625,
+        "no-geonorge:number":"4625"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595867,
     "wof:geomhash":"fd2d3a4620606690183fa473d2d249f1",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878863,
     "wof:name":"Austevoll",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/709/3/1159297093.geojson
+++ b/data/115/929/709/3/1159297093.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.76743,
     "geom:longitude":13.870808,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.747023,
     "lbl:longitude":14.058232,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578223,
         "eg:gisco_id":"NO_1837",
         "eurostat:nuts_2021_id":"1837",
-        "no-geonorge:kommunenum":1837
+        "no-geonorge:kommunenum":1837,
+        "no-geonorge:number":"1837"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595867,
     "wof:geomhash":"093143f08cd496f284fb962ee024f2dd",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878863,
     "wof:name":"Mel\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/709/5/1159297095.geojson
+++ b/data/115/929/709/5/1159297095.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.849441,
     "geom:longitude":11.390173,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.8519,
     "lbl:longitude":11.375832,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578206,
         "eg:gisco_id":"NO_3412",
         "eurostat:nuts_2021_id":"3412",
-        "no-geonorge:kommunenum":3412
+        "no-geonorge:kommunenum":3412,
+        "no-geonorge:number":"3412"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595867,
     "wof:geomhash":"39d214cd7322d80cec2875f9b03072db",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354090,
+    "wof:lastmodified":1695878863,
     "wof:name":"L\u00f8ten",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/709/7/1159297097.geojson
+++ b/data/115/929/709/7/1159297097.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.392321,
     "geom:longitude":11.227336,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.373874,
     "lbl:longitude":11.244562,
     "lbl:max_zoom":18.0,
@@ -178,8 +187,10 @@
         "digitalenvoy:metro_code":578066,
         "eg:gisco_id":"NO_3035",
         "eurostat:nuts_2021_id":"3035",
-        "no-geonorge:kommunenum":3035
+        "no-geonorge:kommunenum":3035,
+        "no-geonorge:number":"3035"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595868,
     "wof:geomhash":"c4f9bb9f7e73e14c2b6b491520bb0082",
@@ -201,7 +212,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354091,
+    "wof:lastmodified":1695878863,
     "wof:name":"Eidsvoll",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/709/9/1159297099.geojson
+++ b/data/115/929/709/9/1159297099.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.224897,
     "geom:longitude":20.373266,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.223163,
     "lbl:longitude":20.362144,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578362,
         "eg:gisco_id":"NO_5425",
         "eurostat:nuts_2021_id":"5425",
-        "no-geonorge:kommunenum":5425
+        "no-geonorge:kommunenum":5425,
+        "no-geonorge:number":"5425"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595869,
     "wof:geomhash":"574c1b48f92e6803d1bd9b4099a96b43",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354091,
+    "wof:lastmodified":1695878864,
     "wof:name":"Storfjord",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/710/7/1159297107.geojson
+++ b/data/115/929/710/7/1159297107.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.848024,
     "geom:longitude":9.49251,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.858206,
     "lbl:longitude":9.497662,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578087,
         "eg:gisco_id":"NO_3050",
         "eurostat:nuts_2021_id":"3050",
-        "no-geonorge:kommunenum":3050
+        "no-geonorge:kommunenum":3050,
+        "no-geonorge:number":"3050"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595871,
     "wof:geomhash":"ff97a7a06531ed6d098a4ced6c7a08f9",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354091,
+    "wof:lastmodified":1695878864,
     "wof:name":"Flesberg",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/711/1/1159297111.geojson
+++ b/data/115/929/711/1/1159297111.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.774483,
     "geom:longitude":6.191716,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.673141,
     "lbl:longitude":6.124711,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578071,
         "eg:gisco_id":"NO_4611",
         "eurostat:nuts_2021_id":"4611",
-        "no-geonorge:kommunenum":4611
+        "no-geonorge:kommunenum":4611,
+        "no-geonorge:number":"4611"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595872,
     "wof:geomhash":"86eeab4042bceccb0a6e24c56ac735c8",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354091,
+    "wof:lastmodified":1695878864,
     "wof:name":"Etne",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/711/3/1159297113.geojson
+++ b/data/115/929/711/3/1159297113.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.37916,
     "geom:longitude":5.588624,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.368729,
     "lbl:longitude":5.536161,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578395,
         "eg:gisco_id":"NO_1146",
         "eurostat:nuts_2021_id":"1146",
-        "no-geonorge:kommunenum":1146
+        "no-geonorge:kommunenum":1146,
+        "no-geonorge:number":"1146"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595874,
     "wof:geomhash":"78146e4f851e8f8ec9770e2e371e2b55",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354091,
+    "wof:lastmodified":1695878864,
     "wof:name":"Tysv\u00e6r",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/711/5/1159297115.geojson
+++ b/data/115/929/711/5/1159297115.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.888531,
     "geom:longitude":15.527503,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.884924,
     "lbl:longitude":15.593191,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578307,
         "eg:gisco_id":"NO_1840",
         "eurostat:nuts_2021_id":"1840",
-        "no-geonorge:kommunenum":1840
+        "no-geonorge:kommunenum":1840,
+        "no-geonorge:number":"1840"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595874,
     "wof:geomhash":"d7f86d3892afd0e23cd53853cf11de23",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354092,
+    "wof:lastmodified":1695878864,
     "wof:name":"Saltdal",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/712/1/1159297121.geojson
+++ b/data/115/929/712/1/1159297121.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.384415,
     "geom:longitude":8.006285,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.403109,
     "lbl:longitude":8.030348,
     "lbl:max_zoom":18.0,
@@ -73,8 +82,10 @@
         "digitalenvoy:metro_code":578333,
         "eg:gisco_id":"NO_1573",
         "eurostat:nuts_2021_id":"1573",
-        "no-geonorge:kommunenum":1573
+        "no-geonorge:kommunenum":1573,
+        "no-geonorge:number":"1573"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595875,
     "wof:geomhash":"46ddc3a1050d7ea7fbb0834d6f27385f",
@@ -96,7 +107,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354092,
+    "wof:lastmodified":1695878864,
     "wof:name":"Sm\u00f8la",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/712/3/1159297123.geojson
+++ b/data/115/929/712/3/1159297123.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.134995,
     "geom:longitude":6.771612,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.126458,
     "lbl:longitude":6.664136,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578075,
         "eg:gisco_id":"NO_4206",
         "eurostat:nuts_2021_id":"4206",
-        "no-geonorge:kommunenum":4206
+        "no-geonorge:kommunenum":4206,
+        "no-geonorge:number":"4206"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595875,
     "wof:geomhash":"6016ff12d82b8e02d89e1ace7f636751",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354092,
+    "wof:lastmodified":1695878865,
     "wof:name":"Farsund",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/712/5/1159297125.geojson
+++ b/data/115/929/712/5/1159297125.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.658224,
     "geom:longitude":11.26713,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.677716,
     "lbl:longitude":11.384363,
     "lbl:max_zoom":18.0,
@@ -169,8 +178,10 @@
         "digitalenvoy:metro_code":578195,
         "eg:gisco_id":"NO_5037",
         "eurostat:nuts_2021_id":"5037",
-        "no-geonorge:kommunenum":5037
+        "no-geonorge:kommunenum":5037,
+        "no-geonorge:number":"5037"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595875,
     "wof:geomhash":"1bfd62c785f3e3691ad0b2c9fb77c797",
@@ -192,7 +203,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878865,
     "wof:name":"Levanger",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/712/7/1159297127.geojson
+++ b/data/115/929/712/7/1159297127.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.334015,
     "geom:longitude":30.628903,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.344342,
     "lbl:longitude":30.624487,
     "lbl:max_zoom":18.0,
@@ -82,8 +91,10 @@
         "digitalenvoy:metro_code":578413,
         "eg:gisco_id":"NO_5404",
         "eurostat:nuts_2021_id":"5404",
-        "no-geonorge:kommunenum":5404
+        "no-geonorge:kommunenum":5404,
+        "no-geonorge:number":"5404"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595876,
     "wof:geomhash":"e9fea24398d9b7306f684a02cdbb6f54",
@@ -105,7 +116,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Vard\u00f8",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/712/9/1159297129.geojson
+++ b/data/115/929/712/9/1159297129.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.034566,
     "geom:longitude":8.884592,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.019468,
     "lbl:longitude":8.862786,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578422,
         "eg:gisco_id":"NO_3452",
         "eurostat:nuts_2021_id":"3452",
-        "no-geonorge:kommunenum":3452
+        "no-geonorge:kommunenum":3452,
+        "no-geonorge:number":"3452"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595876,
     "wof:geomhash":"1135056a5389f5c3c1e4cd56962a0a45",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Vestre Slidre",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/713/1/1159297131.geojson
+++ b/data/115/929/713/1/1159297131.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.133949,
     "geom:longitude":6.981639,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.212924,
     "lbl:longitude":6.877566,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578364,
         "eg:gisco_id":"NO_1525",
         "eurostat:nuts_2021_id":"1525",
-        "no-geonorge:kommunenum":1525
+        "no-geonorge:kommunenum":1525,
+        "no-geonorge:number":"1525"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595876,
     "wof:geomhash":"7c939caadc02c6f1c980c4e5de51fac8",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Stranda",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/713/3/1159297133.geojson
+++ b/data/115/929/713/3/1159297133.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.577429,
     "geom:longitude":11.728974,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.578762,
     "lbl:longitude":11.728847,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578301,
         "eg:gisco_id":"NO_5025",
         "eurostat:nuts_2021_id":"5025",
-        "no-geonorge:kommunenum":5025
+        "no-geonorge:kommunenum":5025,
+        "no-geonorge:number":"5025"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595882,
     "wof:geomhash":"c09a5cd2be8db7e1a6c583745e2a3e35",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"R\u00f8ros",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/713/5/1159297135.geojson
+++ b/data/115/929/713/5/1159297135.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.864621,
     "geom:longitude":5.489973,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.903709,
     "lbl:longitude":5.643441,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578218,
         "eg:gisco_id":"NO_4634",
         "eurostat:nuts_2021_id":"4634",
-        "no-geonorge:kommunenum":4634
+        "no-geonorge:kommunenum":4634,
+        "no-geonorge:number":"4634"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595887,
     "wof:geomhash":"ba98ccf5ed23028d52c54296b4077176",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Masfjorden",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/714/1/1159297141.geojson
+++ b/data/115/929/714/1/1159297141.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.479751,
     "geom:longitude":11.152512,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.483455,
     "lbl:longitude":11.158769,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578329,
         "eg:gisco_id":"NO_3015",
         "eurostat:nuts_2021_id":"3015",
-        "no-geonorge:kommunenum":3015
+        "no-geonorge:kommunenum":3015,
+        "no-geonorge:number":"3015"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595889,
     "wof:geomhash":"29c464187b65bce81382163a8876b3e5",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Skiptvet",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/714/3/1159297143.geojson
+++ b/data/115/929/714/3/1159297143.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.479673,
     "geom:longitude":26.762752,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.313825,
     "lbl:longitude":26.852065,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578188,
         "eg:gisco_id":"NO_5438",
         "eurostat:nuts_2021_id":"5438",
-        "no-geonorge:kommunenum":5438
+        "no-geonorge:kommunenum":5438,
+        "no-geonorge:number":"5438"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595889,
     "wof:geomhash":"fe83a2e7e27666e25630026d61ce45f8",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354093,
+    "wof:lastmodified":1695878866,
     "wof:name":"Lebesby",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/714/9/1159297149.geojson
+++ b/data/115/929/714/9/1159297149.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.122111,
     "geom:longitude":12.503254,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.090513,
     "lbl:longitude":12.522062,
     "lbl:max_zoom":18.0,
@@ -106,8 +115,10 @@
         "digitalenvoy:metro_code":578056,
         "eg:gisco_id":"NO_1827",
         "eurostat:nuts_2021_id":"1827",
-        "no-geonorge:kommunenum":1827
+        "no-geonorge:kommunenum":1827,
+        "no-geonorge:number":"1827"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595895,
     "wof:geomhash":"40930d71d41f9be368fc0f9098e196c0",
@@ -129,7 +140,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"D\u00f8nna",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/715/1/1159297151.geojson
+++ b/data/115/929/715/1/1159297151.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.1914,
     "geom:longitude":8.635919,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.191354,
     "lbl:longitude":8.63588,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578194,
         "eg:gisco_id":"NO_3432",
         "eurostat:nuts_2021_id":"3432",
-        "no-geonorge:kommunenum":3432
+        "no-geonorge:kommunenum":3432,
+        "no-geonorge:number":"3432"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595896,
     "wof:geomhash":"42541ed4705ea39ac9e8f5c43dfac582",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"Lesja",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/715/3/1159297153.geojson
+++ b/data/115/929/715/3/1159297153.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.930141,
     "geom:longitude":12.972804,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.917736,
     "lbl:longitude":12.944222,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578230,
         "eg:gisco_id":"NO_1874",
         "eurostat:nuts_2021_id":"1874",
-        "no-geonorge:kommunenum":1874
+        "no-geonorge:kommunenum":1874,
+        "no-geonorge:number":"1874"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595896,
     "wof:geomhash":"2daabf687621b2641bc5fbd0205525a9",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"Moskenes",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/715/7/1159297157.geojson
+++ b/data/115/929/715/7/1159297157.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.188189,
     "geom:longitude":5.262112,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.191785,
     "lbl:longitude":5.357695,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578157,
         "eg:gisco_id":"NO_4637",
         "eurostat:nuts_2021_id":"4637",
-        "no-geonorge:kommunenum":4637
+        "no-geonorge:kommunenum":4637,
+        "no-geonorge:number":"4637"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595896,
     "wof:geomhash":"acb38a8d82b95984b24594f9d540a24c",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"Hyllestad",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/716/1/1159297161.geojson
+++ b/data/115/929/716/1/1159297161.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.280266,
     "geom:longitude":10.392241,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.264459,
     "lbl:longitude":10.408087,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578161,
         "eg:gisco_id":"NO_3053",
         "eurostat:nuts_2021_id":"3053",
-        "no-geonorge:kommunenum":3053
+        "no-geonorge:kommunenum":3053,
+        "no-geonorge:number":"3053"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595897,
     "wof:geomhash":"d463a3173c4a4640259a34087cd7b3db",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"Jevnaker",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/716/5/1159297165.geojson
+++ b/data/115/929/716/5/1159297165.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.040694,
     "geom:longitude":7.744467,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.037726,
     "lbl:longitude":7.962219,
     "lbl:max_zoom":18.0,
@@ -73,8 +82,10 @@
         "digitalenvoy:metro_code":578184,
         "eg:gisco_id":"NO_4642",
         "eurostat:nuts_2021_id":"4642",
-        "no-geonorge:kommunenum":4642
+        "no-geonorge:kommunenum":4642,
+        "no-geonorge:number":"4642"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595900,
     "wof:geomhash":"175841ce83023bbbd649ce90ee1c4101",
@@ -96,7 +107,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354094,
+    "wof:lastmodified":1695878867,
     "wof:name":"L\u00e6rdal",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/716/7/1159297167.geojson
+++ b/data/115/929/716/7/1159297167.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.981202,
     "geom:longitude":10.739271,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.0159,
     "lbl:longitude":10.704384,
     "lbl:max_zoom":18.0,
@@ -601,8 +610,10 @@
         "digitalenvoy:metro_code":578270,
         "eg:gisco_id":"NO_0301",
         "eurostat:nuts_2021_id":"0301",
-        "no-geonorge:kommunenum":301
+        "no-geonorge:kommunenum":301,
+        "no-geonorge:number":"301"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:coterminous":[
         1495123997,
         85687089
@@ -628,7 +639,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354095,
+    "wof:lastmodified":1695878868,
     "wof:name":"Oslo",
     "wof:parent_id":85687089,
     "wof:placetype":"localadmin",

--- a/data/115/929/717/1/1159297171.geojson
+++ b/data/115/929/717/1/1159297171.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.785024,
     "geom:longitude":11.952462,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.666042,
     "lbl:longitude":11.80766,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578409,
         "eg:gisco_id":"NO_3419",
         "eurostat:nuts_2021_id":"3419",
-        "no-geonorge:kommunenum":3419
+        "no-geonorge:kommunenum":3419,
+        "no-geonorge:number":"3419"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595906,
     "wof:geomhash":"5bf2f81733c0001fe774130c364d2222",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354095,
+    "wof:lastmodified":1695878868,
     "wof:name":"V\u00e5ler",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/717/5/1159297175.geojson
+++ b/data/115/929/717/5/1159297175.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.819233,
     "geom:longitude":11.277322,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.835909,
     "lbl:longitude":11.324667,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578288,
         "eg:gisco_id":"NO_3424",
         "eurostat:nuts_2021_id":"3424",
-        "no-geonorge:kommunenum":3424
+        "no-geonorge:kommunenum":3424,
+        "no-geonorge:number":"3424"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595907,
     "wof:geomhash":"21fa259df0222c2a121be02e868bb49c",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354095,
+    "wof:lastmodified":1695878869,
     "wof:name":"Rendalen",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/717/7/1159297177.geojson
+++ b/data/115/929/717/7/1159297177.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.213554,
     "geom:longitude":21.950344,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.2143,
     "lbl:longitude":21.958378,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578204,
         "eg:gisco_id":"NO_5432",
         "eurostat:nuts_2021_id":"5432",
-        "no-geonorge:kommunenum":5432
+        "no-geonorge:kommunenum":5432,
+        "no-geonorge:number":"5432"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595907,
     "wof:geomhash":"40a4f30ace09ebf6c7d96d4e5f14bfbc",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354096,
+    "wof:lastmodified":1695878869,
     "wof:name":"Loppa",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/718/1/1159297181.geojson
+++ b/data/115/929/718/1/1159297181.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.323054,
     "geom:longitude":12.23226,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.37824,
     "lbl:longitude":12.331231,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578341,
         "eg:gisco_id":"NO_1812",
         "eurostat:nuts_2021_id":"1812",
-        "no-geonorge:kommunenum":1812
+        "no-geonorge:kommunenum":1812,
+        "no-geonorge:number":"1812"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595909,
     "wof:geomhash":"64011528202d2b8e41e1a8880e7ddd15",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354096,
+    "wof:lastmodified":1695878869,
     "wof:name":"S\u00f8mna",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/718/3/1159297183.geojson
+++ b/data/115/929/718/3/1159297183.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.743731,
     "geom:longitude":12.357106,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.733908,
     "lbl:longitude":12.351914,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578153,
         "eg:gisco_id":"NO_5046",
         "eurostat:nuts_2021_id":"5046",
-        "no-geonorge:kommunenum":5046
+        "no-geonorge:kommunenum":5046,
+        "no-geonorge:number":"5046"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595914,
     "wof:geomhash":"90c0d2b21056a5dfb04aa801cdf4a042",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354096,
+    "wof:lastmodified":1695878869,
     "wof:name":"H\u00f8ylandet",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/718/5/1159297185.geojson
+++ b/data/115/929/718/5/1159297185.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.882332,
     "geom:longitude":11.077244,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.878796,
     "lbl:longitude":11.069252,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578282,
         "eg:gisco_id":"NO_3027",
         "eurostat:nuts_2021_id":"3027",
-        "no-geonorge:kommunenum":3027
+        "no-geonorge:kommunenum":3027,
+        "no-geonorge:number":"3027"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595914,
     "wof:geomhash":"b980aed7eb621faef2cf42c3eed058d3",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354096,
+    "wof:lastmodified":1695878869,
     "wof:name":"R\u00e6lingen",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/718/7/1159297187.geojson
+++ b/data/115/929/718/7/1159297187.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.638666,
     "geom:longitude":19.079199,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.59113,
     "lbl:longitude":19.461472,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578387,
         "eg:gisco_id":"NO_5401",
         "eurostat:nuts_2021_id":"5401",
-        "no-geonorge:kommunenum":5401
+        "no-geonorge:kommunenum":5401,
+        "no-geonorge:number":"5401"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595915,
     "wof:geomhash":"aa46f4e7e661a4102952019ff7ace1fc",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354096,
+    "wof:lastmodified":1695878869,
     "wof:name":"Troms\u00f8",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/718/9/1159297189.geojson
+++ b/data/115/929/718/9/1159297189.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.663868,
     "geom:longitude":18.888122,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.699665,
     "lbl:longitude":18.624635,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578035,
         "eg:gisco_id":"NO_5416",
         "eurostat:nuts_2021_id":"5416",
-        "no-geonorge:kommunenum":5416
+        "no-geonorge:kommunenum":5416,
+        "no-geonorge:number":"5416"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595920,
     "wof:geomhash":"1e18d7b0f6bebd46fa9e64b7f2b0524d",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354097,
+    "wof:lastmodified":1695878870,
     "wof:name":"Bardu",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/719/3/1159297193.geojson
+++ b/data/115/929/719/3/1159297193.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.236979,
     "geom:longitude":10.180579,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.232922,
     "lbl:longitude":10.195834,
     "lbl:max_zoom":18.0,
@@ -199,7 +208,8 @@
         "digitalenvoy:metro_code":578311,
         "eg:gisco_id":"NO_3804",
         "eurostat:nuts_2021_id":"3804",
-        "no-geonorge:kommunenum":3804
+        "no-geonorge:kommunenum":3804,
+        "no-geonorge:number":"3804"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -207,6 +217,7 @@
             578010
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595921,
     "wof:geomhash":"ac96e1113c218bb4b87950f1fd9ee72d",
@@ -228,7 +239,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354097,
+    "wof:lastmodified":1695878870,
     "wof:name":"Sandefjord",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/719/5/1159297195.geojson
+++ b/data/115/929/719/5/1159297195.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.802608,
     "geom:longitude":5.347993,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.82454,
     "lbl:longitude":5.472393,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578051,
         "eg:gisco_id":"NO_4648",
         "eurostat:nuts_2021_id":"4648",
-        "no-geonorge:kommunenum":4648
+        "no-geonorge:kommunenum":4648,
+        "no-geonorge:number":"4648"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595921,
     "wof:geomhash":"9ef047f06dfa8715e5477e1a351f84fe",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354097,
+    "wof:lastmodified":1695878870,
     "wof:name":"Bremanger",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/719/9/1159297199.geojson
+++ b/data/115/929/719/9/1159297199.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.043033,
     "geom:longitude":19.422475,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.957085,
     "lbl:longitude":19.215402,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578165,
         "eg:gisco_id":"NO_5423",
         "eurostat:nuts_2021_id":"5423",
-        "no-geonorge:kommunenum":5423
+        "no-geonorge:kommunenum":5423,
+        "no-geonorge:number":"5423"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595922,
     "wof:geomhash":"38324424f3201204efd1e23592dd02a5",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354097,
+    "wof:lastmodified":1695878871,
     "wof:name":"Karls\u00f8y",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/720/1/1159297201.geojson
+++ b/data/115/929/720/1/1159297201.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.811941,
     "geom:longitude":6.885753,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.811704,
     "lbl:longitude":6.864209,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578023,
         "eg:gisco_id":"NO_1547",
         "eurostat:nuts_2021_id":"1547",
-        "no-geonorge:kommunenum":1547
+        "no-geonorge:kommunenum":1547,
+        "no-geonorge:number":"1547"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595922,
     "wof:geomhash":"a7ee8a0037327f4ea7318c46e4906085",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878871,
     "wof:name":"Aukra",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/720/5/1159297205.geojson
+++ b/data/115/929/720/5/1159297205.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.47259,
     "geom:longitude":7.19995,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.469251,
     "lbl:longitude":7.215255,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578124,
         "eg:gisco_id":"NO_4226",
         "eurostat:nuts_2021_id":"4226",
-        "no-geonorge:kommunenum":4226
+        "no-geonorge:kommunenum":4226,
+        "no-geonorge:number":"4226"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595923,
     "wof:geomhash":"32d58a6b51a5f93c727a47caf1a65f5b",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878871,
     "wof:name":"H\u00e6gebostad",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/721/1/1159297211.geojson
+++ b/data/115/929/721/1/1159297211.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.375589,
     "geom:longitude":6.337451,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.36715,
     "lbl:longitude":6.409137,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578338,
         "eg:gisco_id":"NO_1111",
         "eurostat:nuts_2021_id":"1111",
-        "no-geonorge:kommunenum":1111
+        "no-geonorge:kommunenum":1111,
+        "no-geonorge:number":"1111"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595929,
     "wof:geomhash":"bb42fee54a90d260263256426a42b3a9",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878871,
     "wof:name":"Sokndal",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/721/3/1159297213.geojson
+++ b/data/115/929/721/3/1159297213.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.665215,
     "geom:longitude":16.022329,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.675247,
     "lbl:longitude":16.152492,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578176,
         "eg:gisco_id":"NO_5411",
         "eurostat:nuts_2021_id":"5411",
-        "no-geonorge:kommunenum":5411
+        "no-geonorge:kommunenum":5411,
+        "no-geonorge:number":"5411"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595930,
     "wof:geomhash":"8c2a866e04a3336d99e02320b6eb028c",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878871,
     "wof:name":"Kv\u00e6fjord",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/721/7/1159297217.geojson
+++ b/data/115/929/721/7/1159297217.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.711979,
     "geom:longitude":8.386705,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.650728,
     "lbl:longitude":8.556698,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578003,
         "eg:gisco_id":"NO_3043",
         "eurostat:nuts_2021_id":"3043",
-        "no-geonorge:kommunenum":3043
+        "no-geonorge:kommunenum":3043,
+        "no-geonorge:number":"3043"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595931,
     "wof:geomhash":"ae4b203fa8c412712eae22fa5d91f48d",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878872,
     "wof:name":"\u00c5l",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/722/1/1159297221.geojson
+++ b/data/115/929/722/1/1159297221.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.79299,
     "geom:longitude":10.646477,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.79764,
     "lbl:longitude":10.647037,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578243,
         "eg:gisco_id":"NO_3023",
         "eurostat:nuts_2021_id":"3023",
-        "no-geonorge:kommunenum":3023
+        "no-geonorge:kommunenum":3023,
+        "no-geonorge:number":"3023"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595931,
     "wof:geomhash":"8944376cb0a4ecdbe41c77274714d099",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354098,
+    "wof:lastmodified":1695878872,
     "wof:name":"Nesodden",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/722/3/1159297223.geojson
+++ b/data/115/929/722/3/1159297223.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.996317,
     "geom:longitude":5.547653,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.981009,
     "lbl:longitude":5.572013,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578394,
         "eg:gisco_id":"NO_4616",
         "eurostat:nuts_2021_id":"4616",
-        "no-geonorge:kommunenum":4616
+        "no-geonorge:kommunenum":4616,
+        "no-geonorge:number":"4616"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595932,
     "wof:geomhash":"7f8861de1bac7cd304bd670666cd41f0",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878872,
     "wof:name":"Tysnes",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/722/5/1159297225.geojson
+++ b/data/115/929/722/5/1159297225.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.821707,
     "geom:longitude":7.728509,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.8524,
     "lbl:longitude":7.72861,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578429,
         "eg:gisco_id":"NO_3825",
         "eurostat:nuts_2021_id":"3825",
-        "no-geonorge:kommunenum":3825
+        "no-geonorge:kommunenum":3825,
+        "no-geonorge:number":"3825"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595932,
     "wof:geomhash":"8953b4df9cbbc52d5945b705f3897524",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878872,
     "wof:name":"Vinje",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/723/3/1159297233.geojson
+++ b/data/115/929/723/3/1159297233.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.370272,
     "geom:longitude":8.491272,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.374283,
     "lbl:longitude":8.4547,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578182,
         "eg:gisco_id":"NO_3821",
         "eurostat:nuts_2021_id":"3821",
-        "no-geonorge:kommunenum":3821
+        "no-geonorge:kommunenum":3821,
+        "no-geonorge:number":"3821"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595935,
     "wof:geomhash":"dd170924c5640edceddad722fbd9f955",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878872,
     "wof:name":"Kviteseid",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/723/5/1159297235.geojson
+++ b/data/115/929/723/5/1159297235.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.240402,
     "geom:longitude":13.019281,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.229229,
     "lbl:longitude":13.17776,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578242,
         "eg:gisco_id":"NO_1828",
         "eurostat:nuts_2021_id":"1828",
-        "no-geonorge:kommunenum":1828
+        "no-geonorge:kommunenum":1828,
+        "no-geonorge:number":"1828"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595935,
     "wof:geomhash":"c1e880d17e5f49e275630e3314a9576f",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878872,
     "wof:name":"Nesna",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/723/7/1159297237.geojson
+++ b/data/115/929/723/7/1159297237.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.569213,
     "geom:longitude":10.735946,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.576385,
     "lbl:longitude":10.719936,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578420,
         "eg:gisco_id":"NO_3019",
         "eurostat:nuts_2021_id":"3019",
-        "no-geonorge:kommunenum":3019
+        "no-geonorge:kommunenum":3019,
+        "no-geonorge:number":"3019"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595936,
     "wof:geomhash":"e9aee2761bd5049bbf11c3491dae219c",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878872,
     "wof:name":"Vestby",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/723/9/1159297239.geojson
+++ b/data/115/929/723/9/1159297239.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.486581,
     "geom:longitude":11.651519,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.483414,
     "lbl:longitude":11.649075,
     "lbl:max_zoom":18.0,
@@ -103,8 +112,10 @@
         "digitalenvoy:metro_code":578216,
         "eg:gisco_id":"NO_3013",
         "eurostat:nuts_2021_id":"3013",
-        "no-geonorge:kommunenum":3013
+        "no-geonorge:kommunenum":3013,
+        "no-geonorge:number":"3013"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595936,
     "wof:geomhash":"cefe7eda8f32f93eefae85e99c25ab08",
@@ -126,7 +137,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354099,
+    "wof:lastmodified":1695878873,
     "wof:name":"Marker",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/724/1/1159297241.geojson
+++ b/data/115/929/724/1/1159297241.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.589861,
     "geom:longitude":10.781138,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.557116,
     "lbl:longitude":10.900742,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578361,
         "eg:gisco_id":"NO_3423",
         "eurostat:nuts_2021_id":"3423",
-        "no-geonorge:kommunenum":3423
+        "no-geonorge:kommunenum":3423,
+        "no-geonorge:number":"3423"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595937,
     "wof:geomhash":"3e2ad70b50302f35a3e46f5ec723afee",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354100,
+    "wof:lastmodified":1695878873,
     "wof:name":"Stor-Elvdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/724/3/1159297243.geojson
+++ b/data/115/929/724/3/1159297243.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.537552,
     "geom:longitude":9.788506,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.510926,
     "lbl:longitude":9.903666,
     "lbl:max_zoom":18.0,
@@ -60,8 +69,10 @@
     "wof:concordances":{
         "eg:gisco_id":"NO_3438",
         "eurostat:nuts_2021_id":"3438",
-        "no-geonorge:kommunenum":3438
+        "no-geonorge:kommunenum":3438,
+        "no-geonorge:number":"3438"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595944,
     "wof:geomhash":"2cbf8d217b0cd4b6b98a1b6e1233cb32",
@@ -83,7 +94,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354100,
+    "wof:lastmodified":1695878873,
     "wof:name":"S\u00f8r-Fron",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/724/7/1159297247.geojson
+++ b/data/115/929/724/7/1159297247.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.008051,
     "geom:longitude":11.807601,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.017152,
     "lbl:longitude":11.918727,
     "lbl:max_zoom":18.0,
@@ -147,8 +156,10 @@
     "wof:concordances":{
         "eg:gisco_id":"NO_5033",
         "eurostat:nuts_2021_id":"5033",
-        "no-geonorge:kommunenum":5033
+        "no-geonorge:kommunenum":5033,
+        "no-geonorge:number":"5033"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595945,
     "wof:geomhash":"01dc5be4a99bd01c3172252e68b641e3",
@@ -170,7 +181,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354100,
+    "wof:lastmodified":1695878873,
     "wof:name":"Tydal",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/725/1/1159297251.geojson
+++ b/data/115/929/725/1/1159297251.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.536533,
     "geom:longitude":5.553376,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.502748,
     "lbl:longitude":5.565936,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578271,
         "eg:gisco_id":"NO_4630",
         "eurostat:nuts_2021_id":"4630",
-        "no-geonorge:kommunenum":4630
+        "no-geonorge:kommunenum":4630,
+        "no-geonorge:number":"4630"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595951,
     "wof:geomhash":"8f16a0298dbe18098107d7cf503037c8",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354100,
+    "wof:lastmodified":1695878874,
     "wof:name":"Oster\u00f8y",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/725/3/1159297253.geojson
+++ b/data/115/929/725/3/1159297253.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.26532,
     "geom:longitude":10.033934,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.265549,
     "lbl:longitude":10.020168,
     "lbl:max_zoom":18.0,
@@ -142,8 +151,10 @@
         "digitalenvoy:metro_code":578325,
         "eg:gisco_id":"NO_5029",
         "eurostat:nuts_2021_id":"5029",
-        "no-geonorge:kommunenum":5029
+        "no-geonorge:kommunenum":5029,
+        "no-geonorge:number":"5029"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595951,
     "wof:geomhash":"d24be2b09cc559c95569135dd13a9dfa",
@@ -165,7 +176,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"Skaun",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/725/5/1159297255.geojson
+++ b/data/115/929/725/5/1159297255.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.578277,
     "geom:longitude":9.667975,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.549032,
     "lbl:longitude":9.673548,
     "lbl:max_zoom":18.0,
@@ -187,8 +196,10 @@
         "digitalenvoy:metro_code":578170,
         "eg:gisco_id":"NO_3006",
         "eurostat:nuts_2021_id":"3006",
-        "no-geonorge:kommunenum":3006
+        "no-geonorge:kommunenum":3006,
+        "no-geonorge:number":"3006"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595952,
     "wof:geomhash":"9d326524b0a6949b3577d10702ef79db",
@@ -210,7 +221,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"Kongsberg",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/725/7/1159297257.geojson
+++ b/data/115/929/725/7/1159297257.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.345377,
     "geom:longitude":10.859746,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.345524,
     "lbl:longitude":10.855549,
     "lbl:max_zoom":18.0,
@@ -100,8 +109,10 @@
         "digitalenvoy:metro_code":578280,
         "eg:gisco_id":"NO_3017",
         "eurostat:nuts_2021_id":"3017",
-        "no-geonorge:kommunenum":3017
+        "no-geonorge:kommunenum":3017,
+        "no-geonorge:number":"3017"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595953,
     "wof:geomhash":"0eb3ad25667e49408a13dbd6a284ef9d",
@@ -123,7 +134,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"R\u00e5de",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/726/5/1159297265.geojson
+++ b/data/115/929/726/5/1159297265.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.886892,
     "geom:longitude":14.658151,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.893821,
     "lbl:longitude":14.658136,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578037,
         "eg:gisco_id":"NO_1839",
         "eurostat:nuts_2021_id":"1839",
-        "no-geonorge:kommunenum":1839
+        "no-geonorge:kommunenum":1839,
+        "no-geonorge:number":"1839"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595955,
     "wof:geomhash":"2c2517dc99afdf558e4e6ad80dc93edf",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"Beiarn",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/726/7/1159297267.geojson
+++ b/data/115/929/726/7/1159297267.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.367931,
     "geom:longitude":7.361891,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.334184,
     "lbl:longitude":7.428874,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578063,
         "eg:gisco_id":"NO_4619",
         "eurostat:nuts_2021_id":"4619",
-        "no-geonorge:kommunenum":4619
+        "no-geonorge:kommunenum":4619,
+        "no-geonorge:number":"4619"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595955,
     "wof:geomhash":"4e73caafd5c287c85b015f988569cbc9",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"Eidfjord",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/726/9/1159297269.geojson
+++ b/data/115/929/726/9/1159297269.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.997262,
     "geom:longitude":8.561929,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.012918,
     "lbl:longitude":8.571895,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578377,
         "eg:gisco_id":"NO_3818",
         "eurostat:nuts_2021_id":"3818",
-        "no-geonorge:kommunenum":3818
+        "no-geonorge:kommunenum":3818,
+        "no-geonorge:number":"3818"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595956,
     "wof:geomhash":"6d94885c24e28c8501ab9e92d2a0041d",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878874,
     "wof:name":"Tinn",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/727/1/1159297271.geojson
+++ b/data/115/929/727/1/1159297271.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.333265,
     "geom:longitude":5.877448,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.370207,
     "lbl:longitude":5.869237,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578398,
         "eg:gisco_id":"NO_1516",
         "eurostat:nuts_2021_id":"1516",
-        "no-geonorge:kommunenum":1516
+        "no-geonorge:kommunenum":1516,
+        "no-geonorge:number":"1516"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595956,
     "wof:geomhash":"e62d358a9f6d0ff5eedde8126a967687",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354101,
+    "wof:lastmodified":1695878875,
     "wof:name":"Ulstein",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/727/3/1159297273.geojson
+++ b/data/115/929/727/3/1159297273.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.71931,
     "geom:longitude":15.485118,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.676773,
     "lbl:longitude":15.609529,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578349,
         "eg:gisco_id":"NO_1870",
         "eurostat:nuts_2021_id":"1870",
-        "no-geonorge:kommunenum":1870
+        "no-geonorge:kommunenum":1870,
+        "no-geonorge:number":"1870"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595956,
     "wof:geomhash":"78137a67483c9097982b508b6b5f3cd4",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354102,
+    "wof:lastmodified":1695878875,
     "wof:name":"Sortland",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/727/5/1159297275.geojson
+++ b/data/115/929/727/5/1159297275.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.274395,
     "geom:longitude":10.642464,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.262437,
     "lbl:longitude":10.656242,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578269,
         "eg:gisco_id":"NO_5020",
         "eurostat:nuts_2021_id":"5020",
-        "no-geonorge:kommunenum":5020
+        "no-geonorge:kommunenum":5020,
+        "no-geonorge:number":"5020"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595962,
     "wof:geomhash":"62452bffe66ba33e8c0b4ce36405c23b",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354102,
+    "wof:lastmodified":1695878875,
     "wof:name":"Osen",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/727/7/1159297277.geojson
+++ b/data/115/929/727/7/1159297277.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.0214,
     "geom:longitude":6.543552,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.056915,
     "lbl:longitude":6.683241,
     "lbl:max_zoom":18.0,
@@ -142,8 +151,10 @@
         "digitalenvoy:metro_code":578426,
         "eg:gisco_id":"NO_4639",
         "eurostat:nuts_2021_id":"4639",
-        "no-geonorge:kommunenum":4639
+        "no-geonorge:kommunenum":4639,
+        "no-geonorge:number":"4639"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595963,
     "wof:geomhash":"f24c03be6df5cf3cb137b7ec7a8a7a3e",
@@ -165,7 +176,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354102,
+    "wof:lastmodified":1695878876,
     "wof:name":"Vik",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/727/9/1159297279.geojson
+++ b/data/115/929/727/9/1159297279.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.803888,
     "geom:longitude":8.338984,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.803358,
     "lbl:longitude":8.346512,
     "lbl:max_zoom":18.0,
@@ -67,8 +76,10 @@
         "digitalenvoy:metro_code":578008,
         "eg:gisco_id":"NO_4217",
         "eurostat:nuts_2021_id":"4217",
-        "no-geonorge:kommunenum":4217
+        "no-geonorge:kommunenum":4217,
+        "no-geonorge:number":"4217"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595964,
     "wof:geomhash":"9295b0e6ae88b3dfdc8e27a4af6e0f6d",
@@ -90,7 +101,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354102,
+    "wof:lastmodified":1695878876,
     "wof:name":"\u00c5mli",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/728/3/1159297283.geojson
+++ b/data/115/929/728/3/1159297283.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.541118,
     "geom:longitude":7.444964,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.611028,
     "lbl:longitude":7.330097,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578210,
         "eg:gisco_id":"NO_4644",
         "eurostat:nuts_2021_id":"4644",
-        "no-geonorge:kommunenum":4644
+        "no-geonorge:kommunenum":4644,
+        "no-geonorge:number":"4644"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595965,
     "wof:geomhash":"4c76c2570c5f711e794063bfee0260b6",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354102,
+    "wof:lastmodified":1695878876,
     "wof:name":"Luster",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/728/5/1159297285.geojson
+++ b/data/115/929/728/5/1159297285.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.138413,
     "geom:longitude":28.774513,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.265385,
     "lbl:longitude":28.995792,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578400,
         "eg:gisco_id":"NO_5442",
         "eurostat:nuts_2021_id":"5442",
-        "no-geonorge:kommunenum":5442
+        "no-geonorge:kommunenum":5442,
+        "no-geonorge:number":"5442"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595965,
     "wof:geomhash":"1ceb1c152cb41e6c018f617a96f53829",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878876,
     "wof:name":"Nesseby",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/728/7/1159297287.geojson
+++ b/data/115/929/728/7/1159297287.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.925747,
     "geom:longitude":25.818998,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":71.020752,
     "lbl:longitude":25.64803,
     "lbl:max_zoom":18.0,
@@ -196,8 +205,10 @@
         "digitalenvoy:metro_code":578252,
         "eg:gisco_id":"NO_5435",
         "eurostat:nuts_2021_id":"5435",
-        "no-geonorge:kommunenum":5435
+        "no-geonorge:kommunenum":5435,
+        "no-geonorge:number":"5435"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595966,
     "wof:geomhash":"0b03a7dbeae333db790fdbb37f1afe90",
@@ -219,7 +230,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878876,
     "wof:name":"Nordkapp",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/728/9/1159297289.geojson
+++ b/data/115/929/728/9/1159297289.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.562046,
     "geom:longitude":7.031795,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.53741,
     "lbl:longitude":7.057247,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578421,
         "eg:gisco_id":"NO_1535",
         "eurostat:nuts_2021_id":"1535",
-        "no-geonorge:kommunenum":1535
+        "no-geonorge:kommunenum":1535,
+        "no-geonorge:number":"1535"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595971,
     "wof:geomhash":"ebb985d72dbc4cdd9d56c1b1bee30027",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878876,
     "wof:name":"Vestnes",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/729/1/1159297291.geojson
+++ b/data/115/929/729/1/1159297291.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.774283,
     "geom:longitude":9.47554,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.806494,
     "lbl:longitude":9.543611,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578317,
         "eg:gisco_id":"NO_3437",
         "eurostat:nuts_2021_id":"3437",
-        "no-geonorge:kommunenum":3437
+        "no-geonorge:kommunenum":3437,
+        "no-geonorge:number":"3437"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595972,
     "wof:geomhash":"9e0df6748b952fcd56216b8342ce5eba",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878876,
     "wof:name":"Sel",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/729/5/1159297295.geojson
+++ b/data/115/929/729/5/1159297295.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.676854,
     "geom:longitude":10.27079,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.670539,
     "lbl:longitude":10.276203,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578342,
         "eg:gisco_id":"NO_3447",
         "eurostat:nuts_2021_id":"3447",
-        "no-geonorge:kommunenum":3447
+        "no-geonorge:kommunenum":3447,
+        "no-geonorge:number":"3447"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595977,
     "wof:geomhash":"fe8c834eeb9219d8c0343c63393005ca",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878876,
     "wof:name":"S\u00f8ndre Land",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/729/7/1159297297.geojson
+++ b/data/115/929/729/7/1159297297.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.35708,
     "geom:longitude":11.080468,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.310538,
     "lbl:longitude":11.140548,
     "lbl:max_zoom":18.0,
@@ -91,8 +100,10 @@
         "digitalenvoy:metro_code":578381,
         "eg:gisco_id":"NO_3426",
         "eurostat:nuts_2021_id":"3426",
-        "no-geonorge:kommunenum":3426
+        "no-geonorge:kommunenum":3426,
+        "no-geonorge:number":"3426"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595978,
     "wof:geomhash":"b897da79c091af60fea83ccd27c82341",
@@ -114,7 +125,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354103,
+    "wof:lastmodified":1695878877,
     "wof:name":"Tolga",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/730/1/1159297301.geojson
+++ b/data/115/929/730/1/1159297301.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.858416,
     "geom:longitude":7.239129,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.829901,
     "lbl:longitude":7.383686,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578025,
         "eg:gisco_id":"NO_4641",
         "eurostat:nuts_2021_id":"4641",
-        "no-geonorge:kommunenum":4641
+        "no-geonorge:kommunenum":4641,
+        "no-geonorge:number":"4641"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595979,
     "wof:geomhash":"38c630a72b82dd5b2158d8630b559581",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878877,
     "wof:name":"Aurland",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/730/3/1159297303.geojson
+++ b/data/115/929/730/3/1159297303.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.500085,
     "geom:longitude":29.934586,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.482149,
     "lbl:longitude":29.818938,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578036,
         "eg:gisco_id":"NO_5443",
         "eurostat:nuts_2021_id":"5443",
-        "no-geonorge:kommunenum":5443
+        "no-geonorge:kommunenum":5443,
+        "no-geonorge:number":"5443"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595980,
     "wof:geomhash":"48e9609c9d82e4554cbc62daf2a1062b",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878877,
     "wof:name":"B\u00e5tsfjord",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/730/5/1159297305.geojson
+++ b/data/115/929/730/5/1159297305.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.699774,
     "geom:longitude":7.399909,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.696492,
     "lbl:longitude":7.394895,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578016,
         "eg:gisco_id":"NO_4224",
         "eurostat:nuts_2021_id":"4224",
-        "no-geonorge:kommunenum":4224
+        "no-geonorge:kommunenum":4224,
+        "no-geonorge:number":"4224"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595980,
     "wof:geomhash":"e2c08fe2bfbe906382f55e39207a046c",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878877,
     "wof:name":"\u00c5seral",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/730/7/1159297307.geojson
+++ b/data/115/929/730/7/1159297307.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.798785,
     "geom:longitude":22.071896,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.712433,
     "lbl:longitude":22.305805,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578177,
         "eg:gisco_id":"NO_5429",
         "eurostat:nuts_2021_id":"5429",
-        "no-geonorge:kommunenum":5429
+        "no-geonorge:kommunenum":5429,
+        "no-geonorge:number":"5429"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595986,
     "wof:geomhash":"f752dae86f6760a1416460e8f3469c20",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878877,
     "wof:name":"Kv\u00e6nangen",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/730/9/1159297309.geojson
+++ b/data/115/929/730/9/1159297309.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.368711,
     "geom:longitude":13.627144,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.352416,
     "lbl:longitude":13.508016,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578197,
         "eg:gisco_id":"NO_5042",
         "eurostat:nuts_2021_id":"5042",
-        "no-geonorge:kommunenum":5042
+        "no-geonorge:kommunenum":5042,
+        "no-geonorge:number":"5042"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595986,
     "wof:geomhash":"787ff3fb4827abd9405ec5226e884668",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878878,
     "wof:name":"Lierne",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/731/1/1159297311.geojson
+++ b/data/115/929/731/1/1159297311.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.946053,
     "geom:longitude":9.969038,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.930181,
     "lbl:longitude":9.973692,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578254,
         "eg:gisco_id":"NO_3448",
         "eurostat:nuts_2021_id":"3448",
-        "no-geonorge:kommunenum":3448
+        "no-geonorge:kommunenum":3448,
+        "no-geonorge:number":"3448"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595987,
     "wof:geomhash":"a2bfade72c9956a1efdd34dcb69ca8a7",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878878,
     "wof:name":"Nordre Land",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/731/9/1159297319.geojson
+++ b/data/115/929/731/9/1159297319.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.034496,
     "geom:longitude":17.696247,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.060003,
     "lbl:longitude":17.756487,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578060,
         "eg:gisco_id":"NO_5420",
         "eurostat:nuts_2021_id":"5420",
-        "no-geonorge:kommunenum":5420
+        "no-geonorge:kommunenum":5420,
+        "no-geonorge:number":"5420"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595995,
     "wof:geomhash":"0d4ad8b41b411e40745ba007b7b6cd90",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354104,
+    "wof:lastmodified":1695878878,
     "wof:name":"Dyr\u00f8y",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/732/7/1159297327.geojson
+++ b/data/115/929/732/7/1159297327.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.949824,
     "geom:longitude":8.177399,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.962304,
     "lbl:longitude":8.190094,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578376,
         "eg:gisco_id":"NO_1560",
         "eurostat:nuts_2021_id":"1560",
-        "no-geonorge:kommunenum":1560
+        "no-geonorge:kommunenum":1560,
+        "no-geonorge:number":"1560"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595996,
     "wof:geomhash":"9faa0379c1d6b3e3e5acae977a1cbdb1",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354105,
+    "wof:lastmodified":1695878878,
     "wof:name":"Tingvoll",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/732/9/1159297329.geojson
+++ b/data/115/929/732/9/1159297329.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.98486,
     "geom:longitude":9.961905,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.973153,
     "lbl:longitude":9.957559,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578228,
         "eg:gisco_id":"NO_3047",
         "eurostat:nuts_2021_id":"3047",
-        "no-geonorge:kommunenum":3047
+        "no-geonorge:kommunenum":3047,
+        "no-geonorge:number":"3047"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595998,
     "wof:geomhash":"4829fbe0a4ba2eeef335e80d5f9c1097",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354105,
+    "wof:lastmodified":1695878878,
     "wof:name":"Modum",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/733/1/1159297331.geojson
+++ b/data/115/929/733/1/1159297331.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.989647,
     "geom:longitude":12.201895,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.987523,
     "lbl:longitude":12.305912,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578140,
         "eg:gisco_id":"NO_1818",
         "eurostat:nuts_2021_id":"1818",
-        "no-geonorge:kommunenum":1818
+        "no-geonorge:kommunenum":1818,
+        "no-geonorge:number":"1818"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524595999,
     "wof:geomhash":"5aab0eb0c89b299ce94896e28fc6d4d8",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354105,
+    "wof:lastmodified":1695878879,
     "wof:name":"Her\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/733/9/1159297339.geojson
+++ b/data/115/929/733/9/1159297339.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.328638,
     "geom:longitude":12.288411,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.33213,
     "lbl:longitude":12.27765,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578389,
         "eg:gisco_id":"NO_3421",
         "eurostat:nuts_2021_id":"3421",
-        "no-geonorge:kommunenum":3421
+        "no-geonorge:kommunenum":3421,
+        "no-geonorge:number":"3421"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596000,
     "wof:geomhash":"c0dcb46b18ba64ddf6717a7e354525c4",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354105,
+    "wof:lastmodified":1695878879,
     "wof:name":"Trysil",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/734/1/1159297341.geojson
+++ b/data/115/929/734/1/1159297341.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.059785,
     "geom:longitude":8.540907,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.053286,
     "lbl:longitude":8.535658,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578246,
         "eg:gisco_id":"NO_3822",
         "eurostat:nuts_2021_id":"3822",
-        "no-geonorge:kommunenum":3822
+        "no-geonorge:kommunenum":3822,
+        "no-geonorge:number":"3822"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596001,
     "wof:geomhash":"9d3fab289998884d9b8fec3b7b102f7f",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354106,
+    "wof:lastmodified":1695878879,
     "wof:name":"Nissedal",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/734/3/1159297343.geojson
+++ b/data/115/929/734/3/1159297343.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.812815,
     "geom:longitude":15.294883,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.843012,
     "lbl:longitude":15.295431,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578355,
         "eg:gisco_id":"NO_1848",
         "eurostat:nuts_2021_id":"1848",
-        "no-geonorge:kommunenum":1848
+        "no-geonorge:kommunenum":1848,
+        "no-geonorge:number":"1848"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596001,
     "wof:geomhash":"a31c43865d21bf47bb46cd6563117970",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354106,
+    "wof:lastmodified":1695878879,
     "wof:name":"Steigen",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/734/5/1159297345.geojson
+++ b/data/115/929/734/5/1159297345.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.753459,
     "geom:longitude":9.848141,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.750973,
     "lbl:longitude":9.833927,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578274,
         "eg:gisco_id":"NO_3048",
         "eurostat:nuts_2021_id":"3048",
-        "no-geonorge:kommunenum":3048
+        "no-geonorge:kommunenum":3048,
+        "no-geonorge:number":"3048"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596001,
     "wof:geomhash":"58d1e4075f0d28ed4a54b28cc614fac5",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354106,
+    "wof:lastmodified":1695878880,
     "wof:name":"\u00d8vre Eiker",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/734/7/1159297347.geojson
+++ b/data/115/929/734/7/1159297347.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.409408,
     "geom:longitude":12.975024,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.367446,
     "lbl:longitude":13.181132,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578209,
         "eg:gisco_id":"NO_1834",
         "eurostat:nuts_2021_id":"1834",
-        "no-geonorge:kommunenum":1834
+        "no-geonorge:kommunenum":1834,
+        "no-geonorge:number":"1834"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596002,
     "wof:geomhash":"5ab169303e5bd7153da2282efc77bede",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354106,
+    "wof:lastmodified":1695878880,
     "wof:name":"Lur\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/734/9/1159297349.geojson
+++ b/data/115/929/734/9/1159297349.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.139617,
     "geom:longitude":11.499046,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.125548,
     "lbl:longitude":11.45611,
     "lbl:max_zoom":18.0,
@@ -127,7 +136,8 @@
         "digitalenvoy:metro_code":578327,
         "eg:gisco_id":"NO_3034",
         "eurostat:nuts_2021_id":"3034",
-        "no-geonorge:kommunenum":3034
+        "no-geonorge:kommunenum":3034,
+        "no-geonorge:number":"3034"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -135,6 +145,7 @@
             578350
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596002,
     "wof:geomhash":"a706029058081bc46531e2febb063601",
@@ -156,7 +167,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354107,
+    "wof:lastmodified":1695878881,
     "wof:name":"Nes",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/735/5/1159297355.geojson
+++ b/data/115/929/735/5/1159297355.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.70317,
     "geom:longitude":10.663762,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.705896,
     "lbl:longitude":10.678423,
     "lbl:max_zoom":18.0,
@@ -169,8 +178,10 @@
         "digitalenvoy:metro_code":578095,
         "eg:gisco_id":"NO_3022",
         "eurostat:nuts_2021_id":"3022",
-        "no-geonorge:kommunenum":3022
+        "no-geonorge:kommunenum":3022,
+        "no-geonorge:number":"3022"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596004,
     "wof:geomhash":"72795318fc12fdd09bbba5fc9e68b999",
@@ -192,7 +203,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354107,
+    "wof:lastmodified":1695878882,
     "wof:name":"Frogn",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/735/7/1159297357.geojson
+++ b/data/115/929/735/7/1159297357.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.000447,
     "geom:longitude":5.611628,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.000647,
     "lbl:longitude":5.620098,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578285,
         "eg:gisco_id":"NO_1127",
         "eurostat:nuts_2021_id":"1127",
-        "no-geonorge:kommunenum":1127
+        "no-geonorge:kommunenum":1127,
+        "no-geonorge:number":"1127"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596005,
     "wof:geomhash":"2278d9cb6fa0279923d2d2a1d68da0f5",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354107,
+    "wof:lastmodified":1695878882,
     "wof:name":"Randaberg",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/735/9/1159297359.geojson
+++ b/data/115/929/735/9/1159297359.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.683464,
     "geom:longitude":20.106214,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.719283,
     "lbl:longitude":20.109918,
     "lbl:max_zoom":18.0,
@@ -145,8 +154,10 @@
         "digitalenvoy:metro_code":578212,
         "eg:gisco_id":"NO_5424",
         "eurostat:nuts_2021_id":"5424",
-        "no-geonorge:kommunenum":5424
+        "no-geonorge:kommunenum":5424,
+        "no-geonorge:number":"5424"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596005,
     "wof:geomhash":"d5a0ddebfe7d3629ce2179668968d3ea",
@@ -168,7 +179,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354107,
+    "wof:lastmodified":1695878882,
     "wof:name":"Lyngen",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/736/1/1159297361.geojson
+++ b/data/115/929/736/1/1159297361.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.444536,
     "geom:longitude":15.670228,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.404502,
     "lbl:longitude":15.559353,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578202,
         "eg:gisco_id":"NO_1851",
         "eurostat:nuts_2021_id":"1851",
-        "no-geonorge:kommunenum":1851
+        "no-geonorge:kommunenum":1851,
+        "no-geonorge:number":"1851"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596005,
     "wof:geomhash":"ca63ddb4666cd61aa137bcd6d6e37e1a",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878882,
     "wof:name":"L\u00f8dingen",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/736/3/1159297363.geojson
+++ b/data/115/929/736/3/1159297363.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.581484,
     "geom:longitude":5.406118,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.558748,
     "lbl:longitude":5.377528,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578371,
         "eg:gisco_id":"NO_4612",
         "eurostat:nuts_2021_id":"4612",
-        "no-geonorge:kommunenum":4612
+        "no-geonorge:kommunenum":4612,
+        "no-geonorge:number":"4612"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596006,
     "wof:geomhash":"97e92442847479665ab4844e55dd0abe",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878882,
     "wof:name":"Sveio",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/736/5/1159297365.geojson
+++ b/data/115/929/736/5/1159297365.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.887706,
     "geom:longitude":10.470375,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.872737,
     "lbl:longitude":10.514023,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578111,
         "eg:gisco_id":"NO_3407",
         "eurostat:nuts_2021_id":"3407",
-        "no-geonorge:kommunenum":3407
+        "no-geonorge:kommunenum":3407,
+        "no-geonorge:number":"3407"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596006,
     "wof:geomhash":"56c5a07f92b085f3de5ac138c8e1a973",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878882,
     "wof:name":"Gj\u00f8vik",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/736/9/1159297369.geojson
+++ b/data/115/929/736/9/1159297369.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.823729,
     "geom:longitude":5.464611,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.821772,
     "lbl:longitude":5.462589,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578359,
         "eg:gisco_id":"NO_4614",
         "eurostat:nuts_2021_id":"4614",
-        "no-geonorge:kommunenum":4614
+        "no-geonorge:kommunenum":4614,
+        "no-geonorge:number":"4614"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596012,
     "wof:geomhash":"50a83d4c24f06f78b7911265492cefc6",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878883,
     "wof:name":"Stord",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/737/3/1159297373.geojson
+++ b/data/115/929/737/3/1159297373.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.746827,
     "geom:longitude":8.999065,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.762959,
     "lbl:longitude":8.912799,
     "lbl:max_zoom":18.0,
@@ -124,8 +133,10 @@
         "digitalenvoy:metro_code":578113,
         "eg:gisco_id":"NO_3041",
         "eurostat:nuts_2021_id":"3041",
-        "no-geonorge:kommunenum":3041
+        "no-geonorge:kommunenum":3041,
+        "no-geonorge:number":"3041"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596012,
     "wof:geomhash":"c104ee35178634d03d9d538e2b9d2126",
@@ -147,7 +158,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878883,
     "wof:name":"Gol",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/737/5/1159297375.geojson
+++ b/data/115/929/737/5/1159297375.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.271558,
     "geom:longitude":9.85995,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.2863,
     "lbl:longitude":9.860088,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578104,
         "eg:gisco_id":"NO_3441",
         "eurostat:nuts_2021_id":"3441",
-        "no-geonorge:kommunenum":3441
+        "no-geonorge:kommunenum":3441,
+        "no-geonorge:number":"3441"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596017,
     "wof:geomhash":"b487b3a922977806449b194a92f11add",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354108,
+    "wof:lastmodified":1695878883,
     "wof:name":"Gausdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/737/7/1159297377.geojson
+++ b/data/115/929/737/7/1159297377.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.598114,
     "geom:longitude":8.415709,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.55973,
     "lbl:longitude":8.588969,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578096,
         "eg:gisco_id":"NO_4214",
         "eurostat:nuts_2021_id":"4214",
-        "no-geonorge:kommunenum":4214
+        "no-geonorge:kommunenum":4214,
+        "no-geonorge:number":"4214"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596018,
     "wof:geomhash":"39a287b1b56bbc4e96702a0311c5d4d3",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878883,
     "wof:name":"Froland",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/738/1/1159297381.geojson
+++ b/data/115/929/738/1/1159297381.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.765165,
     "geom:longitude":5.598457,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.768581,
     "lbl:longitude":5.586199,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578169,
         "eg:gisco_id":"NO_1120",
         "eurostat:nuts_2021_id":"1120",
-        "no-geonorge:kommunenum":1120
+        "no-geonorge:kommunenum":1120,
+        "no-geonorge:number":"1120"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596020,
     "wof:geomhash":"6d2d96b2b6ebb1ca491135271a992128",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878883,
     "wof:name":"Klepp",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/738/3/1159297383.geojson
+++ b/data/115/929/738/3/1159297383.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.404229,
     "geom:longitude":11.831861,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.410184,
     "lbl:longitude":11.824574,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578224,
         "eg:gisco_id":"NO_5034",
         "eurostat:nuts_2021_id":"5034",
-        "no-geonorge:kommunenum":5034
+        "no-geonorge:kommunenum":5034,
+        "no-geonorge:number":"5034"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596020,
     "wof:geomhash":"8c120104cca42a1a77010e7b8b890f56",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878883,
     "wof:name":"Mer\u00e5ker",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/738/5/1159297385.geojson
+++ b/data/115/929/738/5/1159297385.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.228255,
     "geom:longitude":10.928742,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.257301,
     "lbl:longitude":10.966307,
     "lbl:max_zoom":18.0,
@@ -235,8 +244,10 @@
         "digitalenvoy:metro_code":578094,
         "eg:gisco_id":"NO_3004",
         "eurostat:nuts_2021_id":"3004",
-        "no-geonorge:kommunenum":3004
+        "no-geonorge:kommunenum":3004,
+        "no-geonorge:number":"3004"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596020,
     "wof:geomhash":"d560aee4d35f13078ff3c67910b0e67c",
@@ -258,7 +269,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878883,
     "wof:name":"Fredrikstad",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/738/7/1159297387.geojson
+++ b/data/115/929/738/7/1159297387.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.232349,
     "geom:longitude":29.684252,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.263069,
     "lbl:longitude":29.437436,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578402,
         "eg:gisco_id":"NO_5405",
         "eurostat:nuts_2021_id":"5405",
-        "no-geonorge:kommunenum":5405
+        "no-geonorge:kommunenum":5405,
+        "no-geonorge:number":"5405"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596021,
     "wof:geomhash":"bdc08f581135b10bd211fcdf1ae61394",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878884,
     "wof:name":"Vads\u00f8",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/739/1/1159297391.geojson
+++ b/data/115/929/739/1/1159297391.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.966439,
     "geom:longitude":9.282887,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.936941,
     "lbl:longitude":9.255622,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578249,
         "eg:gisco_id":"NO_3451",
         "eurostat:nuts_2021_id":"3451",
-        "no-geonorge:kommunenum":3451
+        "no-geonorge:kommunenum":3451,
+        "no-geonorge:number":"3451"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596021,
     "wof:geomhash":"fec238a42754e4bcfd93713114d702e3",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878884,
     "wof:name":"Nord-Aurdal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/739/9/1159297399.geojson
+++ b/data/115/929/739/9/1159297399.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.524544,
     "geom:longitude":6.060428,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.559124,
     "lbl:longitude":6.111684,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578106,
         "eg:gisco_id":"NO_1532",
         "eurostat:nuts_2021_id":"1532",
-        "no-geonorge:kommunenum":1532
+        "no-geonorge:kommunenum":1532,
+        "no-geonorge:number":"1532"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596028,
     "wof:geomhash":"5fe364eec09f200405cf51a093eb8ceb",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878884,
     "wof:name":"Giske",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/740/1/1159297401.geojson
+++ b/data/115/929/740/1/1159297401.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.812953,
     "geom:longitude":6.253059,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.814176,
     "lbl:longitude":6.354328,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578110,
         "eg:gisco_id":"NO_1122",
         "eurostat:nuts_2021_id":"1122",
-        "no-geonorge:kommunenum":1122
+        "no-geonorge:kommunenum":1122,
+        "no-geonorge:number":"1122"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596028,
     "wof:geomhash":"5e1292999f1b8f938da26589ff86a05a",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878884,
     "wof:name":"Gjesdal",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/740/3/1159297403.geojson
+++ b/data/115/929/740/3/1159297403.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.794092,
     "geom:longitude":27.898723,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.935636,
     "lbl:longitude":27.948236,
     "lbl:max_zoom":18.0,
@@ -169,8 +178,10 @@
         "digitalenvoy:metro_code":578102,
         "eg:gisco_id":"NO_5439",
         "eurostat:nuts_2021_id":"5439",
-        "no-geonorge:kommunenum":5439
+        "no-geonorge:kommunenum":5439,
+        "no-geonorge:number":"5439"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596035,
     "wof:geomhash":"a28c83afb4e06e0a024a816452410d34",
@@ -192,7 +203,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354109,
+    "wof:lastmodified":1695878884,
     "wof:name":"Gamvik",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/740/5/1159297405.geojson
+++ b/data/115/929/740/5/1159297405.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.644454,
     "geom:longitude":10.622756,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.663903,
     "lbl:longitude":10.613472,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578423,
         "eg:gisco_id":"NO_3443",
         "eurostat:nuts_2021_id":"3443",
-        "no-geonorge:kommunenum":3443
+        "no-geonorge:kommunenum":3443,
+        "no-geonorge:number":"3443"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596035,
     "wof:geomhash":"877020a8eaaae4ae8112aa1dcd361358",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878884,
     "wof:name":"Vestre Toten",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/740/9/1159297409.geojson
+++ b/data/115/929/740/9/1159297409.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.50544,
     "geom:longitude":14.137567,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.498409,
     "lbl:longitude":14.17806,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578134,
         "eg:gisco_id":"NO_1826",
         "eurostat:nuts_2021_id":"1826",
-        "no-geonorge:kommunenum":1826
+        "no-geonorge:kommunenum":1826,
+        "no-geonorge:number":"1826"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596036,
     "wof:geomhash":"a91cbaa656b6e6faf1739aa1c6b32fc9",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878885,
     "wof:name":"Hattfjelldal",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/741/1/1159297411.geojson
+++ b/data/115/929/741/1/1159297411.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.933653,
     "geom:longitude":7.886341,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.950192,
     "lbl:longitude":7.886299,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578330,
         "eg:gisco_id":"NO_3433",
         "eurostat:nuts_2021_id":"3433",
-        "no-geonorge:kommunenum":3433
+        "no-geonorge:kommunenum":3433,
+        "no-geonorge:number":"3433"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596036,
     "wof:geomhash":"df9979c82e6838f156c742a013714440",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878885,
     "wof:name":"Skj\u00e5k",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/741/3/1159297413.geojson
+++ b/data/115/929/741/3/1159297413.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.302062,
     "geom:longitude":5.679781,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.266168,
     "lbl:longitude":5.711043,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578139,
         "eg:gisco_id":"NO_1515",
         "eurostat:nuts_2021_id":"1515",
-        "no-geonorge:kommunenum":1515
+        "no-geonorge:kommunenum":1515,
+        "no-geonorge:number":"1515"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596036,
     "wof:geomhash":"22a7967f4896bbc3d827ed8642295d96",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878885,
     "wof:name":"Her\u00f8y",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/741/5/1159297415.geojson
+++ b/data/115/929/741/5/1159297415.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.217986,
     "geom:longitude":8.474858,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.210507,
     "lbl:longitude":8.481393,
     "lbl:max_zoom":18.0,
@@ -100,8 +109,10 @@
         "digitalenvoy:metro_code":578411,
         "eg:gisco_id":"NO_3454",
         "eurostat:nuts_2021_id":"3454",
-        "no-geonorge:kommunenum":3454
+        "no-geonorge:kommunenum":3454,
+        "no-geonorge:number":"3454"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596037,
     "wof:geomhash":"c8ed92491ba8175fa976dc216233e409",
@@ -123,7 +134,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878885,
     "wof:name":"Vang",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/741/7/1159297417.geojson
+++ b/data/115/929/741/7/1159297417.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.71088,
     "geom:longitude":14.601864,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.668058,
     "lbl:longitude":14.523195,
     "lbl:max_zoom":18.0,
@@ -70,8 +79,10 @@
         "digitalenvoy:metro_code":578047,
         "eg:gisco_id":"NO_1867",
         "eurostat:nuts_2021_id":"1867",
-        "no-geonorge:kommunenum":1867
+        "no-geonorge:kommunenum":1867,
+        "no-geonorge:number":"1867"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596037,
     "wof:geomhash":"1fac0bcb7ebc674b47aa66e7d191af96",
@@ -93,7 +104,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878885,
     "wof:name":"B\u00f8",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/741/9/1159297419.geojson
+++ b/data/115/929/741/9/1159297419.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.244885,
     "geom:longitude":10.663375,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.236052,
     "lbl:longitude":10.677285,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578208,
         "eg:gisco_id":"NO_3054",
         "eurostat:nuts_2021_id":"3054",
-        "no-geonorge:kommunenum":3054
+        "no-geonorge:kommunenum":3054,
+        "no-geonorge:number":"3054"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596038,
     "wof:geomhash":"01e9b0f0291879984e145e088ae466cf",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354110,
+    "wof:lastmodified":1695878886,
     "wof:name":"Lunner",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/742/7/1159297427.geojson
+++ b/data/115/929/742/7/1159297427.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.68106,
     "geom:longitude":29.034213,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.690471,
     "lbl:longitude":29.024254,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578040,
         "eg:gisco_id":"NO_5440",
         "eurostat:nuts_2021_id":"5440",
-        "no-geonorge:kommunenum":5440
+        "no-geonorge:kommunenum":5440,
+        "no-geonorge:number":"5440"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596040,
     "wof:geomhash":"65cee74f4b37b15f32cfe9d0d879ce83",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878886,
     "wof:name":"Berlev\u00e5g",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/742/9/1159297429.geojson
+++ b/data/115/929/742/9/1159297429.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.386551,
     "geom:longitude":6.122449,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.393092,
     "lbl:longitude":6.033372,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578179,
         "eg:gisco_id":"NO_4622",
         "eurostat:nuts_2021_id":"4622",
-        "no-geonorge:kommunenum":4622
+        "no-geonorge:kommunenum":4622,
+        "no-geonorge:number":"4622"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596040,
     "wof:geomhash":"71e3d28650d20d997fb0d4d5ac2670a9",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878886,
     "wof:name":"Kvam",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/743/1/1159297431.geojson
+++ b/data/115/929/743/1/1159297431.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.089004,
     "geom:longitude":11.708595,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.095928,
     "lbl:longitude":11.88327,
     "lbl:max_zoom":18.0,
@@ -91,8 +100,10 @@
         "digitalenvoy:metro_code":578191,
         "eg:gisco_id":"NO_5052",
         "eurostat:nuts_2021_id":"5052",
-        "no-geonorge:kommunenum":5052
+        "no-geonorge:kommunenum":5052,
+        "no-geonorge:number":"5052"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596041,
     "wof:geomhash":"9fc225434bba82f55b654ac8f837d43e",
@@ -114,7 +125,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878886,
     "wof:name":"Leka",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/743/3/1159297433.geojson
+++ b/data/115/929/743/3/1159297433.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.436926,
     "geom:longitude":7.943664,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.42429,
     "lbl:longitude":7.968424,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578160,
         "eg:gisco_id":"NO_4218",
         "eurostat:nuts_2021_id":"4218",
-        "no-geonorge:kommunenum":4218
+        "no-geonorge:kommunenum":4218,
+        "no-geonorge:number":"4218"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596041,
     "wof:geomhash":"1eec17799aa37c5ae81c5f33e5e483bc",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878886,
     "wof:name":"Iveland",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/743/7/1159297437.geojson
+++ b/data/115/929/743/7/1159297437.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.677963,
     "geom:longitude":5.91484,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.795649,
     "lbl:longitude":6.063139,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578407,
         "eg:gisco_id":"NO_4628",
         "eurostat:nuts_2021_id":"4628",
-        "no-geonorge:kommunenum":4628
+        "no-geonorge:kommunenum":4628,
+        "no-geonorge:number":"4628"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596042,
     "wof:geomhash":"2e170572d6f5427b0b28b128ef97dd54",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878886,
     "wof:name":"Vaksdal",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/744/5/1159297445.geojson
+++ b/data/115/929/744/5/1159297445.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.410902,
     "geom:longitude":12.672962,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.370247,
     "lbl:longitude":12.81681,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578052,
         "eg:gisco_id":"NO_1813",
         "eurostat:nuts_2021_id":"1813",
-        "no-geonorge:kommunenum":1813
+        "no-geonorge:kommunenum":1813,
+        "no-geonorge:number":"1813"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596043,
     "wof:geomhash":"4680731fd60b2e63a1d0f503d99eb38b",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354111,
+    "wof:lastmodified":1695878887,
     "wof:name":"Br\u00f8nn\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/744/7/1159297447.geojson
+++ b/data/115/929/744/7/1159297447.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.514396,
     "geom:longitude":12.589525,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.556598,
     "lbl:longitude":12.624342,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578119,
         "eg:gisco_id":"NO_5045",
         "eurostat:nuts_2021_id":"5045",
-        "no-geonorge:kommunenum":5045
+        "no-geonorge:kommunenum":5045,
+        "no-geonorge:number":"5045"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596043,
     "wof:geomhash":"23d557474e9576e668b81dc4f77286dd",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354112,
+    "wof:lastmodified":1695878887,
     "wof:name":"Grong",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/744/9/1159297449.geojson
+++ b/data/115/929/744/9/1159297449.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.766614,
     "geom:longitude":11.102855,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.766876,
     "lbl:longitude":11.102853,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578069,
         "eg:gisco_id":"NO_3028",
         "eurostat:nuts_2021_id":"3028",
-        "no-geonorge:kommunenum":3028
+        "no-geonorge:kommunenum":3028,
+        "no-geonorge:number":"3028"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596044,
     "wof:geomhash":"faf399399d6a8b73cf49a54e20d22d7f",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354112,
+    "wof:lastmodified":1695878887,
     "wof:name":"Enebakk",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/745/1/1159297451.geojson
+++ b/data/115/929/745/1/1159297451.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.801838,
     "geom:longitude":16.458069,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.74547,
     "lbl:longitude":16.468826,
     "lbl:max_zoom":18.0,
@@ -208,8 +217,10 @@
         "digitalenvoy:metro_code":578132,
         "eg:gisco_id":"NO_5402",
         "eurostat:nuts_2021_id":"5402",
-        "no-geonorge:kommunenum":5402
+        "no-geonorge:kommunenum":5402,
+        "no-geonorge:number":"5402"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596045,
     "wof:geomhash":"cb39f07c94f315714ecfeba462b8c4c7",
@@ -231,7 +242,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354112,
+    "wof:lastmodified":1695878887,
     "wof:name":"Harstad",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/745/3/1159297453.geojson
+++ b/data/115/929/745/3/1159297453.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.687626,
     "geom:longitude":17.518938,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.641308,
     "lbl:longitude":17.57409,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578117,
         "eg:gisco_id":"NO_5414",
         "eurostat:nuts_2021_id":"5414",
-        "no-geonorge:kommunenum":5414
+        "no-geonorge:kommunenum":5414,
+        "no-geonorge:number":"5414"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596045,
     "wof:geomhash":"a84a051f1cb97614fba50029fcbb3b55",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354112,
+    "wof:lastmodified":1695878888,
     "wof:name":"Gratangen",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/745/5/1159297455.geojson
+++ b/data/115/929/745/5/1159297455.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.894018,
     "geom:longitude":17.879684,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.881827,
     "lbl:longitude":17.938987,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578306,
         "eg:gisco_id":"NO_5417",
         "eurostat:nuts_2021_id":"5417",
-        "no-geonorge:kommunenum":5417
+        "no-geonorge:kommunenum":5417,
+        "no-geonorge:number":"5417"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596046,
     "wof:geomhash":"e73465b70b35d141b215dd86eb9f075e",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354112,
+    "wof:lastmodified":1695878888,
     "wof:name":"Salangen",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/746/3/1159297463.geojson
+++ b/data/115/929/746/3/1159297463.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.446205,
     "geom:longitude":11.308075,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.560981,
     "lbl:longitude":11.080289,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578267,
         "eg:gisco_id":"NO_3430",
         "eurostat:nuts_2021_id":"3430",
-        "no-geonorge:kommunenum":3430
+        "no-geonorge:kommunenum":3430,
+        "no-geonorge:number":"3430"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596047,
     "wof:geomhash":"68e70d162a2220200a7067f3904b14ee",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354113,
+    "wof:lastmodified":1695878888,
     "wof:name":"Os",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/746/5/1159297465.geojson
+++ b/data/115/929/746/5/1159297465.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":67.265556,
     "geom:longitude":14.832639,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.035602,
     "lbl:longitude":15.044288,
     "lbl:max_zoom":18.0,
@@ -112,8 +121,10 @@
         "digitalenvoy:metro_code":578048,
         "eg:gisco_id":"NO_1804",
         "eurostat:nuts_2021_id":"1804",
-        "no-geonorge:kommunenum":1804
+        "no-geonorge:kommunenum":1804,
+        "no-geonorge:number":"1804"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596052,
     "wof:geomhash":"af2c904b0d2a3488923769dc3f34a3be",
@@ -135,7 +146,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354113,
+    "wof:lastmodified":1695878888,
     "wof:name":"Bod\u00f8",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/746/7/1159297467.geojson
+++ b/data/115/929/746/7/1159297467.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.015259,
     "geom:longitude":7.550155,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.99272,
     "lbl:longitude":7.518967,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578029,
         "eg:gisco_id":"NO_1554",
         "eurostat:nuts_2021_id":"1554",
-        "no-geonorge:kommunenum":1554
+        "no-geonorge:kommunenum":1554,
+        "no-geonorge:number":"1554"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596053,
     "wof:geomhash":"6e6883f28b8775a9710366d72299ea94",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354113,
+    "wof:lastmodified":1695878889,
     "wof:name":"Aver\u00f8y",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/746/9/1159297469.geojson
+++ b/data/115/929/746/9/1159297469.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.959221,
     "geom:longitude":11.736281,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.953898,
     "lbl:longitude":11.742741,
     "lbl:max_zoom":18.0,
@@ -175,8 +184,10 @@
         "digitalenvoy:metro_code":578068,
         "eg:gisco_id":"NO_3420",
         "eurostat:nuts_2021_id":"3420",
-        "no-geonorge:kommunenum":3420
+        "no-geonorge:kommunenum":3420,
+        "no-geonorge:number":"3420"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596053,
     "wof:geomhash":"9f8eba2b52d8748d81276364d7344db8",
@@ -198,7 +209,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878889,
     "wof:name":"Elverum",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/747/1/1159297471.geojson
+++ b/data/115/929/747/1/1159297471.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.57031,
     "geom:longitude":8.010965,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.577647,
     "lbl:longitude":8.010952,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578146,
         "eg:gisco_id":"NO_3044",
         "eurostat:nuts_2021_id":"3044",
-        "no-geonorge:kommunenum":3044
+        "no-geonorge:kommunenum":3044,
+        "no-geonorge:number":"3044"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596054,
     "wof:geomhash":"7eea203e90c947f7cd7cf3a0f7b8b778",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878889,
     "wof:name":"Hol",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/747/3/1159297473.geojson
+++ b/data/115/929/747/3/1159297473.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.910875,
     "geom:longitude":8.467017,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.905305,
     "lbl:longitude":8.510225,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578138,
         "eg:gisco_id":"NO_3042",
         "eurostat:nuts_2021_id":"3042",
-        "no-geonorge:kommunenum":3042
+        "no-geonorge:kommunenum":3042,
+        "no-geonorge:number":"3042"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596055,
     "wof:geomhash":"c7aba38172469fd658154a4979abd6f5",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878890,
     "wof:name":"Hemsedal",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/747/5/1159297475.geojson
+++ b/data/115/929/747/5/1159297475.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.078482,
     "geom:longitude":7.795179,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.066331,
     "lbl:longitude":7.81893,
     "lbl:max_zoom":18.0,
@@ -184,8 +193,10 @@
         "digitalenvoy:metro_code":578174,
         "eg:gisco_id":"NO_1505",
         "eurostat:nuts_2021_id":"1505",
-        "no-geonorge:kommunenum":1505
+        "no-geonorge:kommunenum":1505,
+        "no-geonorge:number":"1505"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596056,
     "wof:geomhash":"42f6d70ce11fa8ade6c16cdd968a86ab",
@@ -207,7 +218,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878890,
     "wof:name":"Kristiansund",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/747/7/1159297477.geojson
+++ b/data/115/929/747/7/1159297477.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.066338,
     "geom:longitude":10.979613,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.057243,
     "lbl:longitude":11.023331,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578156,
         "eg:gisco_id":"NO_3011",
         "eurostat:nuts_2021_id":"3011",
-        "no-geonorge:kommunenum":3011
+        "no-geonorge:kommunenum":3011,
+        "no-geonorge:number":"3011"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596056,
     "wof:geomhash":"3b390ab3821f4188ef1fc22c3fe3424c",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878890,
     "wof:name":"Hvaler",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/748/1/1159297481.geojson
+++ b/data/115/929/748/1/1159297481.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.900876,
     "geom:longitude":5.340713,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.901097,
     "lbl:longitude":5.374219,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578080,
         "eg:gisco_id":"NO_4615",
         "eurostat:nuts_2021_id":"4615",
-        "no-geonorge:kommunenum":4615
+        "no-geonorge:kommunenum":4615,
+        "no-geonorge:number":"4615"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596056,
     "wof:geomhash":"6587f18b1e544abdf5e3d7867c19f3b2",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878890,
     "wof:name":"Fitjar",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/748/3/1159297483.geojson
+++ b/data/115/929/748/3/1159297483.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.069845,
     "geom:longitude":20.686012,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.148006,
     "lbl:longitude":20.631556,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578331,
         "eg:gisco_id":"NO_5427",
         "eurostat:nuts_2021_id":"5427",
-        "no-geonorge:kommunenum":5427
+        "no-geonorge:kommunenum":5427,
+        "no-geonorge:number":"5427"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596057,
     "wof:geomhash":"4dcdf3120dde62e5619d1e8806350575",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354114,
+    "wof:lastmodified":1695878890,
     "wof:name":"Skjerv\u00f8y",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/748/5/1159297485.geojson
+++ b/data/115/929/748/5/1159297485.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.438092,
     "geom:longitude":11.581774,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.444151,
     "lbl:longitude":11.578045,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578253,
         "eg:gisco_id":"NO_3414",
         "eurostat:nuts_2021_id":"3414",
-        "no-geonorge:kommunenum":3414
+        "no-geonorge:kommunenum":3414,
+        "no-geonorge:number":"3414"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596057,
     "wof:geomhash":"654e679c04b50eba6223d9e3c299b564",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354115,
+    "wof:lastmodified":1695878890,
     "wof:name":"Nord-Odal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/749/1/1159297491.geojson
+++ b/data/115/929/749/1/1159297491.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.256965,
     "geom:longitude":8.495136,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.263067,
     "lbl:longitude":8.733745,
     "lbl:max_zoom":18.0,
@@ -100,8 +109,10 @@
         "digitalenvoy:metro_code":578024,
         "eg:gisco_id":"NO_1576",
         "eurostat:nuts_2021_id":"1576",
-        "no-geonorge:kommunenum":1576
+        "no-geonorge:kommunenum":1576,
+        "no-geonorge:number":"1576"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596060,
     "wof:geomhash":"ee4076fe1319528ef469b0b68840aebe",
@@ -123,7 +134,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354115,
+    "wof:lastmodified":1695878891,
     "wof:name":"Aure",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/749/3/1159297493.geojson
+++ b/data/115/929/749/3/1159297493.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.644044,
     "geom:longitude":11.333114,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.638312,
     "lbl:longitude":11.337793,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578353,
         "eg:gisco_id":"NO_3413",
         "eurostat:nuts_2021_id":"3413",
-        "no-geonorge:kommunenum":3413
+        "no-geonorge:kommunenum":3413,
+        "no-geonorge:number":"3413"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596061,
     "wof:geomhash":"f852ad55171cf82203959cc62e3c5b19",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354115,
+    "wof:lastmodified":1695878891,
     "wof:name":"Stange",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/750/1/1159297501.geojson
+++ b/data/115/929/750/1/1159297501.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.886496,
     "geom:longitude":5.611933,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.872384,
     "lbl:longitude":5.625009,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578339,
         "eg:gisco_id":"NO_1124",
         "eurostat:nuts_2021_id":"1124",
-        "no-geonorge:kommunenum":1124
+        "no-geonorge:kommunenum":1124,
+        "no-geonorge:number":"1124"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596063,
     "wof:geomhash":"c48a948c5c5ba0416caeee314d904dcf",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878891,
     "wof:name":"Sola",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/750/3/1159297503.geojson
+++ b/data/115/929/750/3/1159297503.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.400017,
     "geom:longitude":5.796879,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.398011,
     "lbl:longitude":5.835047,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578308,
         "eg:gisco_id":"NO_4623",
         "eurostat:nuts_2021_id":"4623",
-        "no-geonorge:kommunenum":4623
+        "no-geonorge:kommunenum":4623,
+        "no-geonorge:number":"4623"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596063,
     "wof:geomhash":"33f826d42d36901002033b02942c35a0",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878891,
     "wof:name":"Samnanger",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/750/7/1159297507.geojson
+++ b/data/115/929/750/7/1159297507.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.276527,
     "geom:longitude":8.448587,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.338271,
     "lbl:longitude":8.736845,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578256,
         "eg:gisco_id":"NO_3052",
         "eurostat:nuts_2021_id":"3052",
-        "no-geonorge:kommunenum":3052
+        "no-geonorge:kommunenum":3052,
+        "no-geonorge:number":"3052"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596069,
     "wof:geomhash":"9f13ac8453f0f983a392bc018ff3cdd5",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878891,
     "wof:name":"Nore og Uvdal",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/750/9/1159297509.geojson
+++ b/data/115/929/750/9/1159297509.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.518248,
     "geom:longitude":6.608167,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.536898,
     "lbl:longitude":6.760078,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578367,
         "eg:gisco_id":"NO_1134",
         "eurostat:nuts_2021_id":"1134",
-        "no-geonorge:kommunenum":1134
+        "no-geonorge:kommunenum":1134,
+        "no-geonorge:number":"1134"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596070,
     "wof:geomhash":"5a7d3b54f6b2677b326adf10ac20341e",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878892,
     "wof:name":"Suldal",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/751/1/1159297511.geojson
+++ b/data/115/929/751/1/1159297511.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.158948,
     "geom:longitude":10.271188,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.161296,
     "lbl:longitude":10.236343,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578222,
         "eg:gisco_id":"NO_5028",
         "eurostat:nuts_2021_id":"5028",
-        "no-geonorge:kommunenum":5028
+        "no-geonorge:kommunenum":5028,
+        "no-geonorge:number":"5028"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596070,
     "wof:geomhash":"83471b5c158bc32462a6e0b875dd18bf",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878892,
     "wof:name":"Melhus",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/751/3/1159297513.geojson
+++ b/data/115/929/751/3/1159297513.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.295018,
     "geom:longitude":10.087035,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.336903,
     "lbl:longitude":10.019411,
     "lbl:max_zoom":18.0,
@@ -64,8 +73,10 @@
         "digitalenvoy:metro_code":578293,
         "eg:gisco_id":"NO_3007",
         "eurostat:nuts_2021_id":"3007",
-        "no-geonorge:kommunenum":3007
+        "no-geonorge:kommunenum":3007,
+        "no-geonorge:number":"3007"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596076,
     "wof:geomhash":"77c1180103db13f862542dfdc9b3f125",
@@ -87,7 +98,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354116,
+    "wof:lastmodified":1695878892,
     "wof:name":"Ringerike",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/751/9/1159297519.geojson
+++ b/data/115/929/751/9/1159297519.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.127955,
     "geom:longitude":10.391294,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.121283,
     "lbl:longitude":10.337906,
     "lbl:max_zoom":18.0,
@@ -286,8 +295,10 @@
         "digitalenvoy:metro_code":578198,
         "eg:gisco_id":"NO_3405",
         "eurostat:nuts_2021_id":"3405",
-        "no-geonorge:kommunenum":3405
+        "no-geonorge:kommunenum":3405,
+        "no-geonorge:number":"3405"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596077,
     "wof:geomhash":"8082a4b141cb54ac0578d45b93a00e10",
@@ -309,7 +320,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354117,
+    "wof:lastmodified":1695878893,
     "wof:name":"Lillehammer",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/752/1/1159297521.geojson
+++ b/data/115/929/752/1/1159297521.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":63.752852,
     "geom:longitude":8.683354,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.725202,
     "lbl:longitude":8.713931,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578098,
         "eg:gisco_id":"NO_5014",
         "eurostat:nuts_2021_id":"5014",
-        "no-geonorge:kommunenum":5014
+        "no-geonorge:kommunenum":5014,
+        "no-geonorge:number":"5014"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596077,
     "wof:geomhash":"5c8e9bae2c7901fa34dc2506b876e93a",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354117,
+    "wof:lastmodified":1695878893,
     "wof:name":"Fr\u00f8ya",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/752/3/1159297523.geojson
+++ b/data/115/929/752/3/1159297523.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.88253,
     "geom:longitude":9.338371,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.881729,
     "lbl:longitude":9.245557,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578172,
         "eg:gisco_id":"NO_3814",
         "eurostat:nuts_2021_id":"3814",
-        "no-geonorge:kommunenum":3814
+        "no-geonorge:kommunenum":3814,
+        "no-geonorge:number":"3814"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596078,
     "wof:geomhash":"7335a810937d200c95f5d24083ce87a5",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354118,
+    "wof:lastmodified":1695878893,
     "wof:name":"Krager\u00f8",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/752/7/1159297527.geojson
+++ b/data/115/929/752/7/1159297527.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.609594,
     "geom:longitude":7.181796,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.6138,
     "lbl:longitude":7.148681,
     "lbl:max_zoom":18.0,
@@ -153,8 +162,10 @@
     "wof:concordances":{
         "eg:gisco_id":"NO_4620",
         "eurostat:nuts_2021_id":"4620",
-        "no-geonorge:kommunenum":4620
+        "no-geonorge:kommunenum":4620,
+        "no-geonorge:number":"4620"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596085,
     "wof:geomhash":"f3fa5600b2692b229bec5200a6237b2f",
@@ -176,7 +187,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354118,
+    "wof:lastmodified":1695878894,
     "wof:name":"Ulvik",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/752/9/1159297529.geojson
+++ b/data/115/929/752/9/1159297529.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.700988,
     "geom:longitude":8.706855,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.706656,
     "lbl:longitude":8.700699,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578142,
         "eg:gisco_id":"NO_3819",
         "eurostat:nuts_2021_id":"3819",
-        "no-geonorge:kommunenum":3819
+        "no-geonorge:kommunenum":3819,
+        "no-geonorge:number":"3819"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596085,
     "wof:geomhash":"8335c56167e57bec14a35eebe4f2d6ef",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354118,
+    "wof:lastmodified":1695878894,
     "wof:name":"Hjartdal",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/115/929/753/1/1159297531.geojson
+++ b/data/115/929/753/1/1159297531.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.632997,
     "geom:longitude":8.941369,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.626948,
     "lbl:longitude":8.884121,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578390,
         "eg:gisco_id":"NO_4213",
         "eurostat:nuts_2021_id":"4213",
-        "no-geonorge:kommunenum":4213
+        "no-geonorge:kommunenum":4213,
+        "no-geonorge:number":"4213"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596091,
     "wof:geomhash":"2e7149aeede4f508d800f8d17f537b20",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354118,
+    "wof:lastmodified":1695878894,
     "wof:name":"Tvedestrand",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/753/5/1159297535.geojson
+++ b/data/115/929/753/5/1159297535.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":66.093997,
     "geom:longitude":13.073798,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.085014,
     "lbl:longitude":13.140496,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578190,
         "eg:gisco_id":"NO_1822",
         "eurostat:nuts_2021_id":"1822",
-        "no-geonorge:kommunenum":1822
+        "no-geonorge:kommunenum":1822,
+        "no-geonorge:number":"1822"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596091,
     "wof:geomhash":"233e37042d7e20b0d2158b447676cd09",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354118,
+    "wof:lastmodified":1695878894,
     "wof:name":"Leirfjord",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/753/7/1159297537.geojson
+++ b/data/115/929/753/7/1159297537.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.084476,
     "geom:longitude":5.647135,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.043175,
     "lbl:longitude":5.681902,
     "lbl:max_zoom":18.0,
@@ -154,8 +163,10 @@
         "digitalenvoy:metro_code":578412,
         "eg:gisco_id":"NO_1511",
         "eurostat:nuts_2021_id":"1511",
-        "no-geonorge:kommunenum":1511
+        "no-geonorge:kommunenum":1511,
+        "no-geonorge:number":"1511"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596092,
     "wof:geomhash":"9eaf919bfb799c5520d0de9e1f9ebb74",
@@ -177,7 +188,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354119,
+    "wof:lastmodified":1695878894,
     "wof:name":"Vanylven",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/753/9/1159297539.geojson
+++ b/data/115/929/753/9/1159297539.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.050971,
     "geom:longitude":15.777626,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.085966,
     "lbl:longitude":15.801286,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578011,
         "eg:gisco_id":"NO_1871",
         "eurostat:nuts_2021_id":"1871",
-        "no-geonorge:kommunenum":1871
+        "no-geonorge:kommunenum":1871,
+        "no-geonorge:number":"1871"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596092,
     "wof:geomhash":"5e8d380b1f75f968b4b6bbbbdcc122c7",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354119,
+    "wof:lastmodified":1695878894,
     "wof:name":"And\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/754/1/1159297541.geojson
+++ b/data/115/929/754/1/1159297541.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.458473,
     "geom:longitude":10.932636,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.467853,
     "lbl:longitude":10.917579,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578408,
         "eg:gisco_id":"NO_3018",
         "eurostat:nuts_2021_id":"3018",
-        "no-geonorge:kommunenum":3018
+        "no-geonorge:kommunenum":3018,
+        "no-geonorge:number":"3018"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596092,
     "wof:geomhash":"e2b40d75deec74b48bb49af60a22bbc9",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354119,
+    "wof:lastmodified":1695878895,
     "wof:name":"V\u00e5ler",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/754/3/1159297543.geojson
+++ b/data/115/929/754/3/1159297543.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.287401,
     "geom:longitude":11.16001,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.312203,
     "lbl:longitude":11.17964,
     "lbl:max_zoom":18.0,
@@ -217,8 +226,10 @@
         "digitalenvoy:metro_code":578314,
         "eg:gisco_id":"NO_3003",
         "eurostat:nuts_2021_id":"3003",
-        "no-geonorge:kommunenum":3003
+        "no-geonorge:kommunenum":3003,
+        "no-geonorge:number":"3003"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596093,
     "wof:geomhash":"46c8c2f956d69524f8a1fc307a304866",
@@ -240,7 +251,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354119,
+    "wof:lastmodified":1695878895,
     "wof:name":"Sarpsborg",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/754/5/1159297545.geojson
+++ b/data/115/929/754/5/1159297545.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.884824,
     "geom:longitude":7.657688,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.893503,
     "lbl:longitude":7.772763,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578053,
         "eg:gisco_id":"NO_4220",
         "eurostat:nuts_2021_id":"4220",
-        "no-geonorge:kommunenum":4220
+        "no-geonorge:kommunenum":4220,
+        "no-geonorge:number":"4220"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596094,
     "wof:geomhash":"62bfbaf5e152a9da451577ef0c1be82c",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878895,
     "wof:name":"Bygland",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/756/3/1159297563.geojson
+++ b/data/115/929/756/3/1159297563.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.153966,
     "geom:longitude":25.128372,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.086752,
     "lbl:longitude":24.642493,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578278,
         "eg:gisco_id":"NO_5436",
         "eurostat:nuts_2021_id":"5436",
-        "no-geonorge:kommunenum":5436
+        "no-geonorge:kommunenum":5436,
+        "no-geonorge:number":"5436"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596103,
     "wof:geomhash":"502daa84928e9e3c10aac1798312cfab",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878895,
     "wof:name":"Porsanger",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/756/5/1159297565.geojson
+++ b/data/115/929/756/5/1159297565.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":70.835946,
     "geom:longitude":24.783365,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.753411,
     "lbl:longitude":24.915918,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578219,
         "eg:gisco_id":"NO_5434",
         "eurostat:nuts_2021_id":"5434",
-        "no-geonorge:kommunenum":5434
+        "no-geonorge:kommunenum":5434,
+        "no-geonorge:number":"5434"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596103,
     "wof:geomhash":"851240f0cc112a53e44bada5b75bb574",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878896,
     "wof:name":"M\u00e5s\u00f8y",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/757/1/1159297571.geojson
+++ b/data/115/929/757/1/1159297571.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":65.399671,
     "geom:longitude":13.450315,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":65.382167,
     "lbl:longitude":13.497335,
     "lbl:max_zoom":18.0,
@@ -88,8 +97,10 @@
         "digitalenvoy:metro_code":578115,
         "eg:gisco_id":"NO_1825",
         "eurostat:nuts_2021_id":"1825",
-        "no-geonorge:kommunenum":1825
+        "no-geonorge:kommunenum":1825,
+        "no-geonorge:number":"1825"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596103,
     "wof:geomhash":"0234348ab3350afb27635c23d1d44bfb",
@@ -111,7 +122,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878896,
     "wof:name":"Grane",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/757/3/1159297573.geojson
+++ b/data/115/929/757/3/1159297573.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.714478,
     "geom:longitude":8.480417,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.748232,
     "lbl:longitude":8.609089,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578203,
         "eg:gisco_id":"NO_3434",
         "eurostat:nuts_2021_id":"3434",
-        "no-geonorge:kommunenum":3434
+        "no-geonorge:kommunenum":3434,
+        "no-geonorge:number":"3434"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596105,
     "wof:geomhash":"2ad2060946982a6f29548317ce767ecf",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878896,
     "wof:name":"Lom",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/757/5/1159297575.geojson
+++ b/data/115/929/757/5/1159297575.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.441293,
     "geom:longitude":12.225472,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.444607,
     "lbl:longitude":12.177055,
     "lbl:max_zoom":18.0,
@@ -85,8 +94,10 @@
         "digitalenvoy:metro_code":578120,
         "eg:gisco_id":"NO_3417",
         "eurostat:nuts_2021_id":"3417",
-        "no-geonorge:kommunenum":3417
+        "no-geonorge:kommunenum":3417,
+        "no-geonorge:number":"3417"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596106,
     "wof:geomhash":"ffc498cd61f2891171fcb4ac8bd2267b",
@@ -108,7 +119,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354120,
+    "wof:lastmodified":1695878896,
     "wof:name":"Grue",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/757/7/1159297577.geojson
+++ b/data/115/929/757/7/1159297577.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.969013,
     "geom:longitude":5.210559,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.971286,
     "lbl:longitude":5.379971,
     "lbl:max_zoom":18.0,
@@ -160,8 +169,10 @@
         "digitalenvoy:metro_code":578121,
         "eg:gisco_id":"NO_4635",
         "eurostat:nuts_2021_id":"4635",
-        "no-geonorge:kommunenum":4635
+        "no-geonorge:kommunenum":4635,
+        "no-geonorge:number":"4635"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596107,
     "wof:geomhash":"bb0b2cb4457cc14abcf52756e3e61035",
@@ -183,7 +194,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354121,
+    "wof:lastmodified":1695878897,
     "wof:name":"Gulen",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/757/9/1159297579.geojson
+++ b/data/115/929/757/9/1159297579.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.174294,
     "geom:longitude":10.019209,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.201426,
     "lbl:longitude":10.052701,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578089,
         "eg:gisco_id":"NO_3429",
         "eurostat:nuts_2021_id":"3429",
-        "no-geonorge:kommunenum":3429
+        "no-geonorge:kommunenum":3429,
+        "no-geonorge:number":"3429"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596112,
     "wof:geomhash":"95fde0107bc63047593f3963e67f4530",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354121,
+    "wof:lastmodified":1695878897,
     "wof:name":"Folldal",
     "wof:parent_id":1527947263,
     "wof:placetype":"localadmin",

--- a/data/115/929/758/5/1159297585.geojson
+++ b/data/115/929/758/5/1159297585.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.41591,
     "geom:longitude":9.502541,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.414871,
     "lbl:longitude":9.502318,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578083,
         "eg:gisco_id":"NO_3039",
         "eurostat:nuts_2021_id":"3039",
-        "no-geonorge:kommunenum":3039
+        "no-geonorge:kommunenum":3039,
+        "no-geonorge:number":"3039"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596113,
     "wof:geomhash":"1b06e4ddbb4795e29a282e74f247a05d",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Fl\u00e5",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/758/9/1159297589.geojson
+++ b/data/115/929/758/9/1159297589.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.20477,
     "geom:longitude":12.628088,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.190795,
     "lbl:longitude":12.640388,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578334,
         "eg:gisco_id":"NO_5041",
         "eurostat:nuts_2021_id":"5041",
-        "no-geonorge:kommunenum":5041
+        "no-geonorge:kommunenum":5041,
+        "no-geonorge:number":"5041"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596114,
     "wof:geomhash":"da8ca923b0d123ca1f26e5034e586f96",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Sn\u00e5sa",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/759/1/1159297591.geojson
+++ b/data/115/929/759/1/1159297591.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.235957,
     "geom:longitude":8.298552,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.259379,
     "lbl:longitude":8.309628,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578199,
         "eg:gisco_id":"NO_4215",
         "eurostat:nuts_2021_id":"4215",
-        "no-geonorge:kommunenum":4215
+        "no-geonorge:kommunenum":4215,
+        "no-geonorge:number":"4215"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596115,
     "wof:geomhash":"46705f19914ac1ceb926ec65157a47f0",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Lillesand",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/759/3/1159297593.geojson
+++ b/data/115/929/759/3/1159297593.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":69.512242,
     "geom:longitude":21.576955,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.539676,
     "lbl:longitude":21.398515,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578255,
         "eg:gisco_id":"NO_5428",
         "eurostat:nuts_2021_id":"5428",
-        "no-geonorge:kommunenum":5428
+        "no-geonorge:kommunenum":5428,
+        "no-geonorge:number":"5428"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596115,
     "wof:geomhash":"ddb386587353e9269396231ed2e41b63",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Nordreisa",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/760/1/1159297601.geojson
+++ b/data/115/929/760/1/1159297601.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.662601,
     "geom:longitude":6.201102,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.67116,
     "lbl:longitude":6.195455,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578044,
         "eg:gisco_id":"NO_1114",
         "eurostat:nuts_2021_id":"1114",
-        "no-geonorge:kommunenum":1114
+        "no-geonorge:kommunenum":1114,
+        "no-geonorge:number":"1114"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596117,
     "wof:geomhash":"20bacae9f56d3025e7799e1ec2323d1d",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Bjerkreim",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/760/3/1159297603.geojson
+++ b/data/115/929/760/3/1159297603.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.727051,
     "geom:longitude":17.810772,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.673735,
     "lbl:longitude":17.909835,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578187,
         "eg:gisco_id":"NO_5415",
         "eurostat:nuts_2021_id":"5415",
-        "no-geonorge:kommunenum":5415
+        "no-geonorge:kommunenum":5415,
+        "no-geonorge:number":"5415"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596118,
     "wof:geomhash":"933e5355de167eead8f76d9383157ca5",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Lavangen",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/115/929/760/7/1159297607.geojson
+++ b/data/115/929/760/7/1159297607.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.490862,
     "geom:longitude":8.764108,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.532056,
     "lbl:longitude":8.798999,
     "lbl:max_zoom":18.0,
@@ -232,8 +241,10 @@
         "digitalenvoy:metro_code":578014,
         "eg:gisco_id":"NO_4203",
         "eurostat:nuts_2021_id":"4203",
-        "no-geonorge:kommunenum":4203
+        "no-geonorge:kommunenum":4203,
+        "no-geonorge:number":"4203"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596118,
     "wof:geomhash":"e15b53b9969801a0511a05c8080a7319",
@@ -255,7 +266,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354122,
+    "wof:lastmodified":1695878898,
     "wof:name":"Arendal",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/115/929/761/1/1159297611.geojson
+++ b/data/115/929/761/1/1159297611.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":68.064513,
     "geom:longitude":13.236459,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.043571,
     "lbl:longitude":13.295628,
     "lbl:max_zoom":18.0,
@@ -148,8 +157,10 @@
         "digitalenvoy:metro_code":578084,
         "eg:gisco_id":"NO_1859",
         "eurostat:nuts_2021_id":"1859",
-        "no-geonorge:kommunenum":1859
+        "no-geonorge:kommunenum":1859,
+        "no-geonorge:number":"1859"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596120,
     "wof:geomhash":"2d1683e7e0c50bb9814a69505743fd5b",
@@ -171,7 +182,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354123,
+    "wof:lastmodified":1695878899,
     "wof:name":"Flakstad",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/761/3/1159297613.geojson
+++ b/data/115/929/761/3/1159297613.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.920686,
     "geom:longitude":8.862802,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.922243,
     "lbl:longitude":8.863091,
     "lbl:max_zoom":18.0,
@@ -151,8 +160,10 @@
         "digitalenvoy:metro_code":578370,
         "eg:gisco_id":"NO_1566",
         "eurostat:nuts_2021_id":"1566",
-        "no-geonorge:kommunenum":1566
+        "no-geonorge:kommunenum":1566,
+        "no-geonorge:number":"1566"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596120,
     "wof:geomhash":"7c2ff288494c9aa6c88641d4a34ed3d6",
@@ -174,7 +185,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354123,
+    "wof:lastmodified":1695878899,
     "wof:name":"Surnadal",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/115/929/761/7/1159297617.geojson
+++ b/data/115/929/761/7/1159297617.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.364096,
     "geom:longitude":5.390297,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.338792,
     "lbl:longitude":5.416049,
     "lbl:max_zoom":18.0,
@@ -352,8 +361,10 @@
         "digitalenvoy:metro_code":578039,
         "eg:gisco_id":"NO_4601",
         "eurostat:nuts_2021_id":"4601",
-        "no-geonorge:kommunenum":4601
+        "no-geonorge:kommunenum":4601,
+        "no-geonorge:number":"4601"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596121,
     "wof:geomhash":"e2c85a4ce3d9a4fb0c949922dca3528f",
@@ -375,7 +386,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354123,
+    "wof:lastmodified":1695878899,
     "wof:name":"Bergen",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/115/929/761/9/1159297619.geojson
+++ b/data/115/929/761/9/1159297619.geojson
@@ -5,11 +5,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002994,
-    "geom:area_square_m":1780847045.045441,
+    "geom:area_square_m":14746780.518529,
     "geom:bbox":"11.935514,66.427995,12.292881,66.659778",
     "geom:latitude":66.523643,
     "geom:longitude":12.112113,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":66.502554,
     "lbl:longitude":12.044362,
     "lbl:max_zoom":18.0,
@@ -45,11 +54,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "digitalenvoy:metro_code":578384,
-        "no-geonorge:kommunenum":1835
+        "no-geonorge:kommunenum":1835,
+        "no-geonorge:number":"1835"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596122,
-    "wof:geomhash":"f4541091ddfcba7bdd02e7566762d14e",
+    "wof:geomhash":"01625ad22b461c56193957c9f34ff75c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -68,7 +79,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1584030670,
+    "wof:lastmodified":1695878839,
     "wof:name":"Tr\u00e6na",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/115/929/762/1/1159297621.geojson
+++ b/data/115/929/762/1/1159297621.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.150689,
     "geom:longitude":11.196446,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.152468,
     "lbl:longitude":11.19368,
     "lbl:max_zoom":18.0,
@@ -166,8 +175,10 @@
         "digitalenvoy:metro_code":578396,
         "eg:gisco_id":"NO_3033",
         "eurostat:nuts_2021_id":"3033",
-        "no-geonorge:kommunenum":3033
+        "no-geonorge:kommunenum":3033,
+        "no-geonorge:number":"3033"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596122,
     "wof:geomhash":"d35e8a52d2583a945eaa6f0cf13a199c",
@@ -189,7 +200,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354123,
+    "wof:lastmodified":1695878899,
     "wof:name":"Ullensaker",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/762/7/1159297627.geojson
+++ b/data/115/929/762/7/1159297627.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.678053,
     "geom:longitude":10.784677,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.674579,
     "lbl:longitude":10.786054,
     "lbl:max_zoom":18.0,
@@ -61,8 +70,10 @@
         "digitalenvoy:metro_code":578015,
         "eg:gisco_id":"NO_3021",
         "eurostat:nuts_2021_id":"3021",
-        "no-geonorge:kommunenum":3021
+        "no-geonorge:kommunenum":3021,
+        "no-geonorge:number":"3021"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596128,
     "wof:geomhash":"da4bb7e90a6c15834a33e586e9c68915",
@@ -84,7 +95,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354123,
+    "wof:lastmodified":1695878900,
     "wof:name":"\u00c5s",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/115/929/762/9/1159297629.geojson
+++ b/data/115/929/762/9/1159297629.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":58.501273,
     "geom:longitude":6.139845,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.459643,
     "lbl:longitude":6.096952,
     "lbl:max_zoom":18.0,
@@ -163,8 +172,10 @@
         "digitalenvoy:metro_code":578067,
         "eg:gisco_id":"NO_1101",
         "eurostat:nuts_2021_id":"1101",
-        "no-geonorge:kommunenum":1101
+        "no-geonorge:kommunenum":1101,
+        "no-geonorge:number":"1101"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596129,
     "wof:geomhash":"215e65bbc8917f741fe55014ea087b16",
@@ -186,7 +197,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354124,
+    "wof:lastmodified":1695878900,
     "wof:name":"Eigersund",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/763/5/1159297635.geojson
+++ b/data/115/929/763/5/1159297635.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.059645,
     "geom:longitude":5.417883,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.064663,
     "lbl:longitude":5.407269,
     "lbl:max_zoom":18.0,
@@ -60,8 +69,10 @@
     "wof:concordances":{
         "eg:gisco_id":"NO_1144",
         "eurostat:nuts_2021_id":"1144",
-        "no-geonorge:kommunenum":1144
+        "no-geonorge:kommunenum":1144,
+        "no-geonorge:number":"1144"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596130,
     "wof:geomhash":"6f354597a210cefc505f8891edd8224b",
@@ -83,7 +94,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354124,
+    "wof:lastmodified":1695878900,
     "wof:name":"Kvits\u00f8y",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/115/929/763/7/1159297637.geojson
+++ b/data/115/929/763/7/1159297637.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":62.808432,
     "geom:longitude":9.879698,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.846802,
     "lbl:longitude":9.879786,
     "lbl:max_zoom":18.0,
@@ -157,8 +166,10 @@
         "digitalenvoy:metro_code":578289,
         "eg:gisco_id":"NO_5022",
         "eurostat:nuts_2021_id":"5022",
-        "no-geonorge:kommunenum":5022
+        "no-geonorge:kommunenum":5022,
+        "no-geonorge:number":"5022"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596130,
     "wof:geomhash":"1f1ddf0bc9f8605dc70e18ced4b396f7",
@@ -180,7 +191,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354124,
+    "wof:lastmodified":1695878900,
     "wof:name":"Rennebu",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/115/929/763/9/1159297639.geojson
+++ b/data/115/929/763/9/1159297639.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.310068,
     "geom:longitude":9.72533,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.318548,
     "lbl:longitude":9.698327,
     "lbl:max_zoom":18.0,
@@ -118,8 +127,10 @@
         "digitalenvoy:metro_code":578322,
         "eg:gisco_id":"NO_3812",
         "eurostat:nuts_2021_id":"3812",
-        "no-geonorge:kommunenum":3812
+        "no-geonorge:kommunenum":3812,
+        "no-geonorge:number":"3812"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:created":1524596131,
     "wof:geomhash":"663cfd11c53316853696a69a671fe1ad",
@@ -141,7 +152,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354124,
+    "wof:lastmodified":1695878901,
     "wof:name":"Siljan",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/149/511/597/1/1495115971.geojson
+++ b/data/149/511/597/1/1495115971.geojson
@@ -347,15 +347,21 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"NO060",
         "gn:id":3144148,
+        "iso:code":"NO-50",
         "iso:id":"NO-50",
+        "no-geonorge:number":"50",
         "wd:id":"Q127676",
         "wk:page":"Tr\u00f8ndelag"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geom_alt":[
         "whosonfirst-reversegeo"
     ],
-    "wof:geomhash":"974a3fee6a8ad8d20bd62ef63fef683a",
+    "wof:geomhash":"23a454606f7a8c8d5bb3b6f7322f1dfd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -375,7 +381,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1690849636,
+    "wof:lastmodified":1695885241,
     "wof:name":"Tr\u00f8ndelag",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/725/9/1527947259.geojson
+++ b/data/152/794/725/9/1527947259.geojson
@@ -68,8 +68,14 @@
         101751929
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO074"
+        "eurostat:nuts_2021_id":"NO074",
+        "iso:code":"NO-54",
+        "no-geonorge:number":"54"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"6bffadf1d30e5ef528f7c3244be5cdd4",
     "wof:hierarchy":[
@@ -91,7 +97,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493278,
+    "wof:lastmodified":1695885246,
     "wof:name":"Troms og Finnmark",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/1/1527947261.geojson
+++ b/data/152/794/726/1/1527947261.geojson
@@ -68,8 +68,14 @@
         1495165801
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO0A2"
+        "eurostat:nuts_2021_id":"NO0A2",
+        "iso:code":"NO-46",
+        "no-geonorge:number":"46"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"decd459e1377d4c36d5f2c2827fe7300",
     "wof:hierarchy":[
@@ -91,7 +97,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493283,
+    "wof:lastmodified":1695885251,
     "wof:name":"Vestland",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/3/1527947263.geojson
+++ b/data/152/794/726/3/1527947263.geojson
@@ -68,8 +68,14 @@
         1495124017
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO020"
+        "eurostat:nuts_2021_id":"NO020",
+        "iso:code":"NO-34",
+        "no-geonorge:number":"34"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"b4d3cba83a27943bc1d282c42aace00c",
     "wof:hierarchy":[
@@ -91,7 +97,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493287,
+    "wof:lastmodified":1695885255,
     "wof:name":"Innlandet",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/5/1527947265.geojson
+++ b/data/152/794/726/5/1527947265.geojson
@@ -68,8 +68,14 @@
         101751911
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO092"
+        "eurostat:nuts_2021_id":"NO092",
+        "iso:code":"NO-42",
+        "no-geonorge:number":"42"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"0d994bc6b160205fe6e67e2a36ffc2e2",
     "wof:hierarchy":[
@@ -91,7 +97,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493288,
+    "wof:lastmodified":1695885256,
     "wof:name":"Agder",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/7/1527947267.geojson
+++ b/data/152/794/726/7/1527947267.geojson
@@ -68,8 +68,14 @@
         1125829217
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO091"
+        "eurostat:nuts_2021_id":"NO091",
+        "iso:code":"NO-38",
+        "no-geonorge:number":"38"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"df43efa3d60176bcfebbb6330942c149",
     "wof:hierarchy":[
@@ -91,7 +97,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493290,
+    "wof:lastmodified":1695885258,
     "wof:name":"Vestfold og Telemark",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/794/726/9/1527947269.geojson
+++ b/data/152/794/726/9/1527947269.geojson
@@ -70,8 +70,14 @@
         1495123997
     ],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"NO082"
+        "eurostat:nuts_2021_id":"NO082",
+        "iso:code":"NO-30",
+        "no-geonorge:number":"30"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geomhash":"a38b96aaa9d1fbf585ecb9c56a47db99",
     "wof:hierarchy":[
@@ -93,7 +99,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694493291,
+    "wof:lastmodified":1695885259,
     "wof:name":"Viken",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/152/797/100/9/1527971009.geojson
+++ b/data/152/797/100/9/1527971009.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":61.67051,
     "geom:longitude":5.32276,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.649105,
     "lbl:longitude":5.536866,
     "mps:latitude":61.649105,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578406,
         "eg:gisco_id":"NO_4602",
         "eurostat:nuts_2021_id":"4602",
-        "no-geonorge:kommunenum":4602
+        "no-geonorge:kommunenum":4602,
+        "no-geonorge:number":"4602"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578088
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"98cde9f4debd7f3f1813542bd8dd2bcc",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354124,
+    "wof:lastmodified":1695878901,
     "wof:name":"Kinn",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/101/1/1527971011.geojson
+++ b/data/152/797/101/1/1527971011.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":63.340465,
     "geom:longitude":10.43212,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.32818,
     "lbl:longitude":10.510522,
     "mps:latitude":63.32818,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578388,
         "eg:gisco_id":"NO_5001",
         "eurostat:nuts_2021_id":"5001",
-        "no-geonorge:kommunenum":5001
+        "no-geonorge:kommunenum":5001,
+        "no-geonorge:number":"5001"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578168
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"01fae8b6273718a83707067d83e55825",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354125,
+    "wof:lastmodified":1695878901,
     "wof:name":"Trondheim",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/101/5/1527971015.geojson
+++ b/data/152/797/101/5/1527971015.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":64.462763,
     "geom:longitude":11.434026,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.252336,
     "lbl:longitude":11.089984,
     "mps:latitude":64.252336,
@@ -74,13 +83,15 @@
         "digitalenvoy:metro_code":578234,
         "eg:gisco_id":"NO_5007",
         "eurostat:nuts_2021_id":"5007",
-        "no-geonorge:kommunenum":5007
+        "no-geonorge:kommunenum":5007,
+        "no-geonorge:number":"5007"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578233
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"42de62a6f2333d3868a5cf1c4a242e10",
     "wof:hierarchy":[
@@ -101,7 +112,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354125,
+    "wof:lastmodified":1695878901,
     "wof:name":"Namsos",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/101/7/1527971017.geojson
+++ b/data/152/797/101/7/1527971017.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.741257,
     "geom:longitude":10.879524,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.751284,
     "lbl:longitude":10.88154,
     "mps:latitude":59.751284,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578262,
         "eg:gisco_id":"NO_3020",
         "eurostat:nuts_2021_id":"3020",
-        "no-geonorge:kommunenum":3020
+        "no-geonorge:kommunenum":3020,
+        "no-geonorge:number":"3020"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578327
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"1531305d403fbf00e1f385c044c92757",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354125,
+    "wof:lastmodified":1695878902,
     "wof:name":"Nordre Follo",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/101/9/1527971019.geojson
+++ b/data/152/797/101/9/1527971019.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.94781,
     "geom:longitude":11.206034,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.949197,
     "lbl:longitude":11.223193,
     "mps:latitude":59.949197,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578350,
         "eg:gisco_id":"NO_3030",
         "eurostat:nuts_2021_id":"3030",
-        "no-geonorge:kommunenum":3030
+        "no-geonorge:kommunenum":3030,
+        "no-geonorge:number":"3030"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -62,6 +72,7 @@
             578327
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"7999d52fe57229edf2e41199ebb5c7e2",
     "wof:hierarchy":[
@@ -82,7 +93,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354126,
+    "wof:lastmodified":1695878902,
     "wof:name":"Lillestr\u00f8m",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/102/1/1527971021.geojson
+++ b/data/152/797/102/1/1527971021.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.705076,
     "geom:longitude":10.463181,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.765952,
     "lbl:longitude":10.423541,
     "mps:latitude":59.765952,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578017,
         "eg:gisco_id":"NO_3025",
         "eurostat:nuts_2021_id":"3025",
-        "no-geonorge:kommunenum":3025
+        "no-geonorge:kommunenum":3025,
+        "no-geonorge:number":"3025"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578155
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"9b1b005f6c1a3e68f18e238108edd747",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354126,
+    "wof:lastmodified":1695878903,
     "wof:name":"Asker",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/102/3/1527971023.geojson
+++ b/data/152/797/102/3/1527971023.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":61.469852,
     "geom:longitude":6.113438,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.464367,
     "lbl:longitude":6.113428,
     "mps:latitude":61.464367,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578090,
         "eg:gisco_id":"NO_4647",
         "eurostat:nuts_2021_id":"4647",
-        "no-geonorge:kommunenum":4647
+        "no-geonorge:kommunenum":4647,
+        "no-geonorge:number":"4647"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -62,6 +72,7 @@
             578238
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"fbcbfa47904f02615cc711cf7e414e81",
     "wof:hierarchy":[
@@ -82,7 +93,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878903,
     "wof:name":"Sunnfjord",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/102/5/1527971025.geojson
+++ b/data/152/797/102/5/1527971025.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":61.13908,
     "geom:longitude":5.925408,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.225557,
     "lbl:longitude":5.951564,
     "mps:latitude":61.225557,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578152,
         "eg:gisco_id":"NO_4638",
         "eurostat:nuts_2021_id":"4638",
-        "no-geonorge:kommunenum":4638
+        "no-geonorge:kommunenum":4638,
+        "no-geonorge:number":"4638"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"5c11d2d386cb4643ffec1da2479679a7",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878903,
     "wof:name":"H\u00f8yanger",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/102/9/1527971029.geojson
+++ b/data/152/797/102/9/1527971029.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.783104,
     "geom:longitude":4.931579,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.763518,
     "lbl:longitude":4.927734,
     "mps:latitude":60.763518,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578028,
         "eg:gisco_id":"NO_4632",
         "eurostat:nuts_2021_id":"4632",
-        "no-geonorge:kommunenum":4632
+        "no-geonorge:kommunenum":4632,
+        "no-geonorge:number":"4632"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"bdb9c7171b42e8836432373fb676f809",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878904,
     "wof:name":"Austrheim",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/103/3/1527971033.geojson
+++ b/data/152/797/103/3/1527971033.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.671505,
     "geom:longitude":5.282574,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.685996,
     "lbl:longitude":5.291527,
     "mps:latitude":60.685996,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578200,
         "eg:gisco_id":"NO_4631",
         "eurostat:nuts_2021_id":"4631",
-        "no-geonorge:kommunenum":4631
+        "no-geonorge:kommunenum":4631,
+        "no-geonorge:number":"4631"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578281
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"b7e74bab38c8584b59b27d28e909311b",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878904,
     "wof:name":"Alver",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/103/5/1527971035.geojson
+++ b/data/152/797/103/5/1527971035.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.77309,
     "geom:longitude":4.713424,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.762944,
     "lbl:longitude":4.725296,
     "mps:latitude":60.762944,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578077,
         "eg:gisco_id":"NO_4633",
         "eurostat:nuts_2021_id":"4633",
-        "no-geonorge:kommunenum":4633
+        "no-geonorge:kommunenum":4633,
+        "no-geonorge:number":"4633"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"13b0d36f35480e711817ed1474b383be",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878904,
     "wof:name":"Fedje",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/103/9/1527971039.geojson
+++ b/data/152/797/103/9/1527971039.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":61.395119,
     "geom:longitude":5.16798,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.417473,
     "lbl:longitude":5.270608,
     "mps:latitude":61.417473,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578020,
         "eg:gisco_id":"NO_4645",
         "eurostat:nuts_2021_id":"4645",
-        "no-geonorge:kommunenum":4645
+        "no-geonorge:kommunenum":4645,
+        "no-geonorge:number":"4645"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"939e1c7ec27563398e04d8fd017f82f3",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354127,
+    "wof:lastmodified":1695878904,
     "wof:name":"Askvoll",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/104/1/1527971041.geojson
+++ b/data/152/797/104/1/1527971041.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":61.293447,
     "geom:longitude":6.789633,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.309089,
     "lbl:longitude":6.845969,
     "mps:latitude":61.309089,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578336,
         "eg:gisco_id":"NO_4640",
         "eurostat:nuts_2021_id":"4640",
-        "no-geonorge:kommunenum":4640
+        "no-geonorge:kommunenum":4640,
+        "no-geonorge:number":"4640"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578031
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"01bbd11c88418edd7dd1e9245428960f",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878904,
     "wof:name":"Sogndal",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/104/3/1527971043.geojson
+++ b/data/152/797/104/3/1527971043.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.097655,
     "geom:longitude":6.81401,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.062687,
     "lbl:longitude":6.882541,
     "mps:latitude":60.062687,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578397,
         "eg:gisco_id":"NO_4618",
         "eurostat:nuts_2021_id":"4618",
-        "no-geonorge:kommunenum":4618
+        "no-geonorge:kommunenum":4618,
+        "no-geonorge:number":"4618"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578163
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"f9fcc714f398f27052028ed4d2cb5203",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878904,
     "wof:name":"Ullensvang",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/104/5/1527971045.geojson
+++ b/data/152/797/104/5/1527971045.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.217309,
     "geom:longitude":5.695601,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.242461,
     "lbl:longitude":5.825776,
     "mps:latitude":60.242461,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578268,
         "eg:gisco_id":"NO_4624",
         "eurostat:nuts_2021_id":"4624",
-        "no-geonorge:kommunenum":4624
+        "no-geonorge:kommunenum":4624,
+        "no-geonorge:number":"4624"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578099
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"bd4a50c5c48745dd704a458838dc0879",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878905,
     "wof:name":"Bj\u00f8rnafjorden",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/104/7/1527971047.geojson
+++ b/data/152/797/104/7/1527971047.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":60.357766,
     "geom:longitude":5.01099,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.340878,
     "lbl:longitude":5.035723,
     "mps:latitude":60.340878,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578082,
         "eg:gisco_id":"NO_4626",
         "eurostat:nuts_2021_id":"4626",
-        "no-geonorge:kommunenum":4626
+        "no-geonorge:kommunenum":4626,
+        "no-geonorge:number":"4626"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578276
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"718693377d56a64e2cc7716c3f4fb028",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878905,
     "wof:name":"\u00d8ygarden",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/797/105/1/1527971051.geojson
+++ b/data/152/797/105/1/1527971051.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.581091,
     "geom:longitude":7.764847,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.577099,
     "lbl:longitude":7.714967,
     "mps:latitude":58.577099,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578074,
         "eg:gisco_id":"NO_4219",
         "eurostat:nuts_2021_id":"4219",
-        "no-geonorge:kommunenum":4219
+        "no-geonorge:kommunenum":4219,
+        "no-geonorge:number":"4219"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"6fd833af7fbe37f4dc576d9166c65e45",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878905,
     "wof:name":"Evje og Hornnes",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/105/3/1527971053.geojson
+++ b/data/152/797/105/3/1527971053.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.437634,
     "geom:longitude":7.203753,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.480878,
     "lbl:longitude":7.211521,
     "mps:latitude":59.480878,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578054,
         "eg:gisco_id":"NO_4222",
         "eurostat:nuts_2021_id":"4222",
-        "no-geonorge:kommunenum":4222
+        "no-geonorge:kommunenum":4222,
+        "no-geonorge:number":"4222"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"4ef18233b9ae823e4f02beb65a445506",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354128,
+    "wof:lastmodified":1695878905,
     "wof:name":"Bykle",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/105/5/1527971055.geojson
+++ b/data/152/797/105/5/1527971055.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.164737,
     "geom:longitude":7.432119,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.144605,
     "lbl:longitude":7.391567,
     "mps:latitude":59.144605,
@@ -56,8 +65,10 @@
         "digitalenvoy:metro_code":578410,
         "eg:gisco_id":"NO_4221",
         "eurostat:nuts_2021_id":"4221",
-        "no-geonorge:kommunenum":4221
+        "no-geonorge:kommunenum":4221,
+        "no-geonorge:number":"4221"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"acaff3d787e637fba16f8e26a9b75010",
     "wof:hierarchy":[
@@ -78,7 +89,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354129,
+    "wof:lastmodified":1695878905,
     "wof:name":"Valle",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/105/7/1527971057.geojson
+++ b/data/152/797/105/7/1527971057.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.447009,
     "geom:longitude":8.195848,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.430854,
     "lbl:longitude":8.213351,
     "mps:latitude":58.430854,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578042,
         "eg:gisco_id":"NO_4216",
         "eurostat:nuts_2021_id":"4216",
-        "no-geonorge:kommunenum":4216
+        "no-geonorge:kommunenum":4216,
+        "no-geonorge:number":"4216"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"5167c0bc03c509e5c3da46dd790d1b64",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354129,
+    "wof:lastmodified":1695878906,
     "wof:name":"Birkenes",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/105/9/1527971059.geojson
+++ b/data/152/797/105/9/1527971059.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.866873,
     "geom:longitude":6.840259,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.889698,
     "lbl:longitude":6.808445,
     "mps:latitude":58.889698,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578323,
         "eg:gisco_id":"NO_4228",
         "eurostat:nuts_2021_id":"4228",
-        "no-geonorge:kommunenum":4228
+        "no-geonorge:kommunenum":4228,
+        "no-geonorge:number":"4228"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"d4db590769630ffb61637057db825d58",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354129,
+    "wof:lastmodified":1695878906,
     "wof:name":"Sirdal",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/106/1/1527971061.geojson
+++ b/data/152/797/106/1/1527971061.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.254585,
     "geom:longitude":7.204726,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.192567,
     "lbl:longitude":7.119077,
     "mps:latitude":58.192567,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578022,
         "eg:gisco_id":"NO_4225",
         "eurostat:nuts_2021_id":"4225",
-        "no-geonorge:kommunenum":4225
+        "no-geonorge:kommunenum":4225,
+        "no-geonorge:number":"4225"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578211
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"89f0cf4b2cb564f763ab9b9b6b5ee3f9",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354129,
+    "wof:lastmodified":1695878906,
     "wof:name":"Lyngdal",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/106/3/1527971063.geojson
+++ b/data/152/797/106/3/1527971063.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.184144,
     "geom:longitude":7.858314,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.158665,
     "lbl:longitude":7.85023,
     "mps:latitude":58.158665,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578173,
         "eg:gisco_id":"NO_4204",
         "eurostat:nuts_2021_id":"4204",
-        "no-geonorge:kommunenum":4204
+        "no-geonorge:kommunenum":4204,
+        "no-geonorge:number":"4204"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578337
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"3d7833cc4a2667685a1064a51b7e632e",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354129,
+    "wof:lastmodified":1695878906,
     "wof:name":"Kristiansand",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/106/5/1527971065.geojson
+++ b/data/152/797/106/5/1527971065.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.179074,
     "geom:longitude":7.451137,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.144129,
     "lbl:longitude":7.451606,
     "mps:latitude":58.144129,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578215,
         "eg:gisco_id":"NO_4205",
         "eurostat:nuts_2021_id":"4205",
-        "no-geonorge:kommunenum":4205
+        "no-geonorge:kommunenum":4205,
+        "no-geonorge:number":"4205"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578201
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"e5eb0950b928d95e54308444a52a7249",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354130,
+    "wof:lastmodified":1695878907,
     "wof:name":"Lindesnes",
     "wof:parent_id":1527947265,
     "wof:placetype":"localadmin",

--- a/data/152/797/106/9/1527971069.geojson
+++ b/data/152/797/106/9/1527971069.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.429816,
     "geom:longitude":9.135424,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.412949,
     "lbl:longitude":9.206776,
     "mps:latitude":59.412949,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578046,
         "eg:gisco_id":"NO_3817",
         "eurostat:nuts_2021_id":"3817",
-        "no-geonorge:kommunenum":3817
+        "no-geonorge:kommunenum":3817,
+        "no-geonorge:number":"3817"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578316
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"3d9ffd0a1a4c2b2f157faec3ca2f7747",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354130,
+    "wof:lastmodified":1695878907,
     "wof:name":"Midt-Telemark",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/107/1/1527971071.geojson
+++ b/data/152/797/107/1/1527971071.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.461987,
     "geom:longitude":7.911361,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.469017,
     "lbl:longitude":7.779869,
     "mps:latitude":59.469017,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578380,
         "eg:gisco_id":"NO_3824",
         "eurostat:nuts_2021_id":"3824",
-        "no-geonorge:kommunenum":3824
+        "no-geonorge:kommunenum":3824,
+        "no-geonorge:number":"3824"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"3e2d6125ca45fdd5cce41807295d8c2f",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354130,
+    "wof:lastmodified":1695878907,
     "wof:name":"Tokke",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/107/3/1527971073.geojson
+++ b/data/152/797/107/3/1527971073.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.364548,
     "geom:longitude":10.290235,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.384445,
     "lbl:longitude":10.272586,
     "mps:latitude":59.384445,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578382,
         "eg:gisco_id":"NO_3803",
         "eurostat:nuts_2021_id":"3803",
-        "no-geonorge:kommunenum":3803
+        "no-geonorge:kommunenum":3803,
+        "no-geonorge:number":"3803"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578287
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"1368e9fc8df83be8d22ee82b6cda4881",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354130,
+    "wof:lastmodified":1695878907,
     "wof:name":"T\u00f8nsberg",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/107/5/1527971075.geojson
+++ b/data/152/797/107/5/1527971075.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.565791,
     "geom:longitude":10.160348,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.564201,
     "lbl:longitude":10.139644,
     "mps:latitude":59.564201,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578309,
         "eg:gisco_id":"NO_3802",
         "eurostat:nuts_2021_id":"3802",
-        "no-geonorge:kommunenum":3802
+        "no-geonorge:kommunenum":3802,
+        "no-geonorge:number":"3802"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578145
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"a9275dff7bed46f846d91c5596096579",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354131,
+    "wof:lastmodified":1695878908,
     "wof:name":"Holmestrand",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/107/7/1527971077.geojson
+++ b/data/152/797/107/7/1527971077.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.4024,
     "geom:longitude":10.422511,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.39959,
     "lbl:longitude":10.431853,
     "mps:latitude":59.39959,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578151,
         "eg:gisco_id":"NO_3801",
         "eurostat:nuts_2021_id":"3801",
-        "no-geonorge:kommunenum":3801
+        "no-geonorge:kommunenum":3801,
+        "no-geonorge:number":"3801"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"9a8bb11926f2ac8f80798406026d0acf",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354131,
+    "wof:lastmodified":1695878908,
     "wof:name":"Horten",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/107/9/1527971079.geojson
+++ b/data/152/797/107/9/1527971079.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.653058,
     "geom:longitude":9.151935,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.657278,
     "lbl:longitude":9.188217,
     "mps:latitude":59.657278,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578257,
         "eg:gisco_id":"NO_3808",
         "eurostat:nuts_2021_id":"3808",
-        "no-geonorge:kommunenum":3808
+        "no-geonorge:kommunenum":3808,
+        "no-geonorge:number":"3808"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"6aff8cfe19b25db37631c8f1c02933b7",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354131,
+    "wof:lastmodified":1695878908,
     "wof:name":"Notodden",
     "wof:parent_id":1527947267,
     "wof:placetype":"localadmin",

--- a/data/152/797/108/1/1527971081.geojson
+++ b/data/152/797/108/1/1527971081.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.450809,
     "geom:longitude":7.757627,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.487836,
     "lbl:longitude":7.88293,
     "mps:latitude":62.487836,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578286,
         "eg:gisco_id":"NO_1539",
         "eurostat:nuts_2021_id":"1539",
-        "no-geonorge:kommunenum":1539
+        "no-geonorge:kommunenum":1539,
+        "no-geonorge:number":"1539"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"7e88db763dff56e0b4c944d3d69db56f",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354131,
+    "wof:lastmodified":1695878908,
     "wof:name":"Rauma",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/108/3/1527971083.geojson
+++ b/data/152/797/108/3/1527971083.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":68.269378,
     "geom:longitude":17.316649,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.213677,
     "lbl:longitude":17.770129,
     "mps:latitude":68.213677,
@@ -62,13 +71,15 @@
         "digitalenvoy:metro_code":578237,
         "eg:gisco_id":"NO_1806",
         "eurostat:nuts_2021_id":"1806",
-        "no-geonorge:kommunenum":1806
+        "no-geonorge:kommunenum":1806,
+        "no-geonorge:number":"1806"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578032
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"ace6fd4a2beced210eae11d4c84a714b",
     "wof:hierarchy":[
@@ -89,7 +100,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354131,
+    "wof:lastmodified":1695878909,
     "wof:name":"Narvik",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/152/797/108/7/1527971087.geojson
+++ b/data/152/797/108/7/1527971087.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.227436,
     "geom:longitude":6.340985,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.236976,
     "lbl:longitude":6.27745,
     "mps:latitude":62.236976,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578266,
         "eg:gisco_id":"NO_1520",
         "eurostat:nuts_2021_id":"1520",
-        "no-geonorge:kommunenum":1520
+        "no-geonorge:kommunenum":1520,
+        "no-geonorge:number":"1520"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"8f29e50948bac06849135af15da0d09c",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354132,
+    "wof:lastmodified":1695878909,
     "wof:name":"\u00d8rsta",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/108/9/1527971089.geojson
+++ b/data/152/797/108/9/1527971089.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":69.315532,
     "geom:longitude":17.61541,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":69.307756,
     "lbl:longitude":17.642794,
     "mps:latitude":69.307756,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578385,
         "eg:gisco_id":"NO_5421",
         "eurostat:nuts_2021_id":"5421",
-        "no-geonorge:kommunenum":5421
+        "no-geonorge:kommunenum":5421,
+        "no-geonorge:number":"5421"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -62,6 +72,7 @@
             578038
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"24fee42055e82f03a4864699dfc791bc",
     "wof:hierarchy":[
@@ -82,7 +93,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354132,
+    "wof:lastmodified":1695878909,
     "wof:name":"Senja",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/152/797/109/1/1527971091.geojson
+++ b/data/152/797/109/1/1527971091.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.539127,
     "geom:longitude":6.58234,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.535781,
     "lbl:longitude":6.748347,
     "mps:latitude":62.535781,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578004,
         "eg:gisco_id":"NO_1507",
         "eurostat:nuts_2021_id":"1507",
-        "no-geonorge:kommunenum":1507
+        "no-geonorge:kommunenum":1507,
+        "no-geonorge:number":"1507"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -62,6 +72,7 @@
             578130
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"577d99146268ef25e03c4df7bed5d9d9",
     "wof:hierarchy":[
@@ -82,7 +93,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354132,
+    "wof:lastmodified":1695878910,
     "wof:name":"\u00c5lesund",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/109/3/1527971093.geojson
+++ b/data/152/797/109/3/1527971093.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.638252,
     "geom:longitude":7.901644,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.678197,
     "lbl:longitude":7.977979,
     "mps:latitude":62.678197,
@@ -59,7 +68,8 @@
         "digitalenvoy:metro_code":578229,
         "eg:gisco_id":"NO_1506",
         "eurostat:nuts_2021_id":"1506",
-        "no-geonorge:kommunenum":1506
+        "no-geonorge:kommunenum":1506,
+        "no-geonorge:number":"1506"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -67,6 +77,7 @@
             578225
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"25a09a771f906fa1835ad370105051b8",
     "wof:hierarchy":[
@@ -87,7 +98,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354132,
+    "wof:lastmodified":1695878910,
     "wof:name":"Molde",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/109/5/1527971095.geojson
+++ b/data/152/797/109/5/1527971095.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":70.482515,
     "geom:longitude":23.90988,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":70.299866,
     "lbl:longitude":24.106797,
     "mps:latitude":70.299866,
@@ -74,13 +83,15 @@
         "digitalenvoy:metro_code":578129,
         "eg:gisco_id":"NO_5406",
         "eurostat:nuts_2021_id":"5406",
-        "no-geonorge:kommunenum":5406
+        "no-geonorge:kommunenum":5406,
+        "no-geonorge:number":"5406"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578178
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"896da35bc1d1ead428490144ce61a960",
     "wof:hierarchy":[
@@ -101,7 +112,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354133,
+    "wof:lastmodified":1695878911,
     "wof:name":"Hammerfest",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/152/797/109/7/1527971097.geojson
+++ b/data/152/797/109/7/1527971097.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":68.573757,
     "geom:longitude":16.718057,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":68.640924,
     "lbl:longitude":16.972078,
     "mps:latitude":68.640924,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578378,
         "eg:gisco_id":"NO_5412",
         "eurostat:nuts_2021_id":"5412",
-        "no-geonorge:kommunenum":5412
+        "no-geonorge:kommunenum":5412,
+        "no-geonorge:number":"5412"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578324
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"e962d5c13295356bb4e5ef5c5c7b7467",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354133,
+    "wof:lastmodified":1695878911,
     "wof:name":"Tjeldsund",
     "wof:parent_id":1527947259,
     "wof:placetype":"localadmin",

--- a/data/152/797/109/9/1527971099.geojson
+++ b/data/152/797/109/9/1527971099.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.886233,
     "geom:longitude":7.225327,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.885882,
     "lbl:longitude":7.287899,
     "mps:latitude":62.885882,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578093,
         "eg:gisco_id":"NO_1579",
         "eurostat:nuts_2021_id":"1579",
-        "no-geonorge:kommunenum":1579
+        "no-geonorge:kommunenum":1579,
+        "no-geonorge:number":"1579"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578062
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"f059a116e6564f34b1e429040d5b0bf7",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354133,
+    "wof:lastmodified":1695878911,
     "wof:name":"Hustadvika",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/110/1/1527971101.geojson
+++ b/data/152/797/110/1/1527971101.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.287715,
     "geom:longitude":7.382272,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.291332,
     "lbl:longitude":7.536006,
     "mps:latitude":62.291332,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578250,
         "eg:gisco_id":"NO_1578",
         "eurostat:nuts_2021_id":"1578",
-        "no-geonorge:kommunenum":1578
+        "no-geonorge:kommunenum":1578,
+        "no-geonorge:number":"1578"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578360
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"7f0ffd03aa140be7a1cf9ef73d69600d",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354134,
+    "wof:lastmodified":1695878911,
     "wof:name":"Fjord",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/110/5/1527971105.geojson
+++ b/data/152/797/110/5/1527971105.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":62.053852,
     "geom:longitude":6.276137,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":62.028916,
     "lbl:longitude":6.498197,
     "mps:latitude":62.028916,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578430,
         "eg:gisco_id":"NO_1577",
         "eurostat:nuts_2021_id":"1577",
-        "no-geonorge:kommunenum":1577
+        "no-geonorge:kommunenum":1577,
+        "no-geonorge:number":"1577"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578150
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"cccbeb1bb28f737663e34dd2f93604b2",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354134,
+    "wof:lastmodified":1695878911,
     "wof:name":"Volda",
     "wof:parent_id":85687123,
     "wof:placetype":"localadmin",

--- a/data/152/797/110/7/1527971107.geojson
+++ b/data/152/797/110/7/1527971107.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":67.910759,
     "geom:longitude":16.170008,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":67.711614,
     "lbl:longitude":16.341186,
     "mps:latitude":67.711614,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578393,
         "eg:gisco_id":"NO_1875",
         "eurostat:nuts_2021_id":"1875",
-        "no-geonorge:kommunenum":1875
+        "no-geonorge:kommunenum":1875,
+        "no-geonorge:number":"1875"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578128
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"6fded22acf922018175cfffb4cf92678",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354134,
+    "wof:lastmodified":1695878912,
     "wof:name":"Hamar\u00f8y",
     "wof:parent_id":85687135,
     "wof:placetype":"localadmin",

--- a/data/152/797/110/9/1527971109.geojson
+++ b/data/152/797/110/9/1527971109.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.714377,
     "geom:longitude":10.149764,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.736131,
     "lbl:longitude":10.087713,
     "mps:latitude":59.736131,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578058,
         "eg:gisco_id":"NO_3005",
         "eurostat:nuts_2021_id":"3005",
-        "no-geonorge:kommunenum":3005
+        "no-geonorge:kommunenum":3005,
+        "no-geonorge:number":"3005"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578372
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"e334881a3ed8fc2bd7aa79d3545cc724",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354134,
+    "wof:lastmodified":1695878912,
     "wof:name":"Drammen",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/111/1/1527971111.geojson
+++ b/data/152/797/111/1/1527971111.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.412479,
     "geom:longitude":10.707358,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.405942,
     "lbl:longitude":10.714657,
     "mps:latitude":59.405942,
@@ -68,13 +77,15 @@
         "digitalenvoy:metro_code":578231,
         "eg:gisco_id":"NO_3002",
         "eurostat:nuts_2021_id":"3002",
-        "no-geonorge:kommunenum":3002
+        "no-geonorge:kommunenum":3002,
+        "no-geonorge:number":"3002"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578305
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"a4e39f54eaf0cef0559a4277253b0f58",
     "wof:hierarchy":[
@@ -95,7 +106,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354134,
+    "wof:lastmodified":1695878912,
     "wof:name":"Moss",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/111/3/1527971113.geojson
+++ b/data/152/797/111/3/1527971113.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.596542,
     "geom:longitude":11.216347,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.58793,
     "lbl:longitude":11.307608,
     "mps:latitude":59.58793,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578018,
         "eg:gisco_id":"NO_3014",
         "eurostat:nuts_2021_id":"3014",
-        "no-geonorge:kommunenum":3014
+        "no-geonorge:kommunenum":3014,
+        "no-geonorge:number":"3014"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -63,6 +73,7 @@
             578386
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"96a27c9bf93e337e3217620b39506bf6",
     "wof:hierarchy":[
@@ -83,7 +94,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354135,
+    "wof:lastmodified":1695878912,
     "wof:name":"Indre \u00d8stfold",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/797/111/5/1527971115.geojson
+++ b/data/152/797/111/5/1527971115.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.036008,
     "geom:longitude":6.064148,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.064091,
     "lbl:longitude":6.057722,
     "mps:latitude":59.064091,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578363,
         "eg:gisco_id":"NO_1130",
         "eurostat:nuts_2021_id":"1130",
-        "no-geonorge:kommunenum":1130
+        "no-geonorge:kommunenum":1130,
+        "no-geonorge:number":"1130"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"44d2b8ebe0be146eb90f379dd8840a39",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354135,
+    "wof:lastmodified":1695878913,
     "wof:name":"Strand",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/152/797/111/7/1527971117.geojson
+++ b/data/152/797/111/7/1527971117.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.703404,
     "geom:longitude":6.451226,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.703406,
     "lbl:longitude":6.451217,
     "mps:latitude":59.703406,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578315,
         "eg:gisco_id":"NO_1135",
         "eurostat:nuts_2021_id":"1135",
-        "no-geonorge:kommunenum":1135
+        "no-geonorge:kommunenum":1135,
+        "no-geonorge:number":"1135"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"5b2d7b912df8cac1c8b263acc4a77b56",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354135,
+    "wof:lastmodified":1695878913,
     "wof:name":"Sauda",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/152/797/111/9/1527971119.geojson
+++ b/data/152/797/111/9/1527971119.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":64.903176,
     "geom:longitude":11.659155,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.852857,
     "lbl:longitude":11.935539,
     "mps:latitude":64.852857,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578427,
         "eg:gisco_id":"NO_5060",
         "eurostat:nuts_2021_id":"5060",
-        "no-geonorge:kommunenum":5060
+        "no-geonorge:kommunenum":5060,
+        "no-geonorge:number":"5060"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578232
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"b9e08aa467bc8719e0b8da9e798520d6",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354135,
+    "wof:lastmodified":1695878913,
     "wof:name":"N\u00e6r\u00f8ysund",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/112/3/1527971123.geojson
+++ b/data/152/797/112/3/1527971123.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":63.268499,
     "geom:longitude":9.646338,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.254355,
     "lbl:longitude":9.641208,
     "mps:latitude":63.254355,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578263,
         "eg:gisco_id":"NO_5059",
         "eurostat:nuts_2021_id":"5059",
-        "no-geonorge:kommunenum":5059
+        "no-geonorge:kommunenum":5059,
+        "no-geonorge:number":"5059"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -62,6 +72,7 @@
             578335
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"ab1fda3a679659acdaa913adbbb66ecb",
     "wof:hierarchy":[
@@ -82,7 +93,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354137,
+    "wof:lastmodified":1695878915,
     "wof:name":"Orkland",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/112/5/1527971125.geojson
+++ b/data/152/797/112/5/1527971125.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":63.541067,
     "geom:longitude":8.786927,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.561126,
     "lbl:longitude":8.815243,
     "mps:latitude":63.561126,
@@ -53,8 +62,10 @@
         "digitalenvoy:metro_code":578141,
         "eg:gisco_id":"NO_5056",
         "eurostat:nuts_2021_id":"5056",
-        "no-geonorge:kommunenum":5056
+        "no-geonorge:kommunenum":5056,
+        "no-geonorge:number":"5056"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"20787f85389a932e3a6a7407f04377bf",
     "wof:hierarchy":[
@@ -75,7 +86,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354137,
+    "wof:lastmodified":1695878915,
     "wof:name":"Hitra",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/112/7/1527971127.geojson
+++ b/data/152/797/112/7/1527971127.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":63.227552,
     "geom:longitude":8.894492,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.292326,
     "lbl:longitude":8.992848,
     "mps:latitude":63.292326,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578136,
         "eg:gisco_id":"NO_5055",
         "eurostat:nuts_2021_id":"5055",
-        "no-geonorge:kommunenum":5055
+        "no-geonorge:kommunenum":5055,
+        "no-geonorge:number":"5055"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578126
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"f74b35b45de10fecc2325bffcec3888c",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354137,
+    "wof:lastmodified":1695878916,
     "wof:name":"Heim",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/113/1/1527971131.geojson
+++ b/data/152/797/113/1/1527971131.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":64.032207,
     "geom:longitude":10.39331,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.010971,
     "lbl:longitude":10.442839,
     "mps:latitude":64.010971,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578001,
         "eg:gisco_id":"NO_5058",
         "eurostat:nuts_2021_id":"5058",
-        "no-geonorge:kommunenum":5058
+        "no-geonorge:kommunenum":5058,
+        "no-geonorge:number":"5058"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578297
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"8952028292b5eb2a19f884c73cfbe1e7",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354138,
+    "wof:lastmodified":1695878916,
     "wof:name":"\u00c5fjord",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/113/3/1527971133.geojson
+++ b/data/152/797/113/3/1527971133.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":63.793188,
     "geom:longitude":9.842153,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":63.81303,
     "lbl:longitude":9.93013,
     "mps:latitude":63.81303,
@@ -53,13 +62,15 @@
         "digitalenvoy:metro_code":578045,
         "eg:gisco_id":"NO_5057",
         "eurostat:nuts_2021_id":"5057",
-        "no-geonorge:kommunenum":5057
+        "no-geonorge:kommunenum":5057,
+        "no-geonorge:number":"5057"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578264
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"8b53e102d6e79f0d54062667ebc3abe8",
     "wof:hierarchy":[
@@ -80,7 +91,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354138,
+    "wof:lastmodified":1695878916,
     "wof:name":"\u00d8rland",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/797/113/5/1527971135.geojson
+++ b/data/152/797/113/5/1527971135.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":58.978291,
     "geom:longitude":6.314982,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.960475,
     "lbl:longitude":6.432189,
     "mps:latitude":58.960475,
@@ -68,13 +77,15 @@
         "digitalenvoy:metro_code":578312,
         "eg:gisco_id":"NO_1108",
         "eurostat:nuts_2021_id":"1108",
-        "no-geonorge:kommunenum":1108
+        "no-geonorge:kommunenum":1108,
+        "no-geonorge:number":"1108"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578091
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"71704263dfcfaa42379f1104ff0e40f0",
     "wof:hierarchy":[
@@ -95,7 +106,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354138,
+    "wof:lastmodified":1695878916,
     "wof:name":"Sandnes",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/152/797/113/7/1527971137.geojson
+++ b/data/152/797/113/7/1527971137.geojson
@@ -24,6 +24,15 @@
     "geom:latitude":59.117825,
     "geom:longitude":5.807797,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":58.963097,
     "lbl:longitude":5.694527,
     "mps:latitude":58.963097,
@@ -53,7 +62,8 @@
         "digitalenvoy:metro_code":578354,
         "eg:gisco_id":"NO_1103",
         "eurostat:nuts_2021_id":"1103",
-        "no-geonorge:kommunenum":1103
+        "no-geonorge:kommunenum":1103,
+        "no-geonorge:number":"1103"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
@@ -61,6 +71,7 @@
             578079
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"a21a03172035f37eeef84ec0985109fe",
     "wof:hierarchy":[
@@ -81,7 +92,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354139,
+    "wof:lastmodified":1695878917,
     "wof:name":"Stavanger",
     "wof:parent_id":85687085,
     "wof:placetype":"localadmin",

--- a/data/152/804/108/3/1528041083.geojson
+++ b/data/152/804/108/3/1528041083.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":64.049143,
     "geom:longitude":11.530282,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":64.0729,
     "lbl:longitude":11.675914,
     "mps:latitude":64.0729,
@@ -58,13 +67,15 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":578356,
         "eg:gisco_id":"NO_5006",
-        "eurostat:nuts_2021_id":"5006"
+        "eurostat:nuts_2021_id":"5006",
+        "no-geonorge:number":"5006"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578419
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"c63b216b5c4b91a69e8798206f1bdf85",
     "wof:hierarchy":[
@@ -85,7 +96,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354139,
+    "wof:lastmodified":1695878917,
     "wof:name":"Steinkjer",
     "wof:parent_id":1495115971,
     "wof:placetype":"localadmin",

--- a/data/152/804/108/5/1528041085.geojson
+++ b/data/152/804/108/5/1528041085.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":59.820132,
     "geom:longitude":11.613193,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":59.835675,
     "lbl:longitude":11.61326,
     "mps:latitude":59.835675,
@@ -49,8 +58,10 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":578026,
         "eg:gisco_id":"NO_3026",
-        "eurostat:nuts_2021_id":"3026"
+        "eurostat:nuts_2021_id":"3026",
+        "no-geonorge:number":"3026"
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"e3a47cf916214c5212b72c61f99c2d7a",
     "wof:hierarchy":[
@@ -71,7 +82,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354139,
+    "wof:lastmodified":1695878917,
     "wof:name":"Aurskog-H\u00f8land",
     "wof:parent_id":1527947269,
     "wof:placetype":"localadmin",

--- a/data/152/804/108/9/1528041089.geojson
+++ b/data/152/804/108/9/1528041089.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":61.977119,
     "geom:longitude":5.758742,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":61.9525,
     "lbl:longitude":5.938851,
     "mps:latitude":61.9525,
@@ -49,13 +58,15 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":578061,
         "eg:gisco_id":"NO_4649",
-        "eurostat:nuts_2021_id":"4649"
+        "eurostat:nuts_2021_id":"4649",
+        "no-geonorge:number":"4649"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578319
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"54cce9a29dee2c7e9c2c189152a5e1fd",
     "wof:hierarchy":[
@@ -76,7 +87,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354139,
+    "wof:lastmodified":1695878918,
     "wof:name":"Stad",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/152/804/109/1/1528041091.geojson
+++ b/data/152/804/109/1/1528041091.geojson
@@ -22,6 +22,15 @@
     "geom:latitude":60.686851,
     "geom:longitude":6.469228,
     "iso:country":"NO",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nob_x_preferred_placetype":[
+        "kommune"
+    ],
     "lbl:latitude":60.690286,
     "lbl:longitude":6.508113,
     "mps:latitude":60.690286,
@@ -49,13 +58,15 @@
     "wof:concordances":{
         "digitalenvoy:metro_code":578431,
         "eg:gisco_id":"NO_4621",
-        "eurostat:nuts_2021_id":"4621"
+        "eurostat:nuts_2021_id":"4621",
+        "no-geonorge:number":"4621"
     },
     "wof:concordances_alt":{
         "digitalenvoy:metro_code":[
             578116
         ]
     },
+    "wof:concordances_official":"no-geonorge:number",
     "wof:country":"NO",
     "wof:geomhash":"3d0a9985525b8b071078ffad64b04256",
     "wof:hierarchy":[
@@ -76,7 +87,7 @@
         "nob",
         "nno"
     ],
-    "wof:lastmodified":1684354140,
+    "wof:lastmodified":1695878918,
     "wof:name":"Voss",
     "wof:parent_id":1527947261,
     "wof:placetype":"localadmin",

--- a/data/856/333/41/85633341.geojson
+++ b/data/856/333/41/85633341.geojson
@@ -1427,6 +1427,7 @@
         "hasc:id":"NO",
         "icao:code":"LN",
         "ioc:id":"NOR",
+        "iso:code":"NO",
         "itu:id":"NOR",
         "m49:code":"578",
         "marc:id":"no",
@@ -1440,6 +1441,7 @@
         "wk:page":"Norway",
         "wmo:id":"NO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NO",
     "wof:country_alpha3":"NOR",
     "wof:geom_alt":[
@@ -1466,7 +1468,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1694492257,
+    "wof:lastmodified":1695881370,
     "wof:name":"Norway",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/755/39/85675539.geojson
+++ b/data/856/755/39/85675539.geojson
@@ -398,15 +398,21 @@
         "gn:id":607072,
         "gp:id":23424953,
         "hasc:id":"SJ.SV",
+        "iso:code":"NO-21",
         "iso:id":"SJ-21",
         "itu:id":"NOR",
+        "no-geonorge:number":"21",
         "qs_pg:id":550256,
         "wd:id":"Q842829",
         "wk:page":"Svalbard and Jan Mayen",
         "wmo:id":"SZ"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
-    "wof:geomhash":"f5abb5efea4b80be7fc2bdb9786e6d87",
+    "wof:geomhash":"b342e438b575253bf408a7e5248b80f0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -426,7 +432,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1690849333,
+    "wof:lastmodified":1695885228,
     "wof:name":"Svalbard",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/870/85/85687085.geojson
+++ b/data/856/870/85/85687085.geojson
@@ -432,15 +432,21 @@
         "gn:id":3141558,
         "gp:id":2346397,
         "hasc:id":"NO.RO",
+        "iso:code":"NO-11",
         "iso:id":"NO-11",
+        "no-geonorge:number":"11",
         "unlc:id":"NO-11",
         "wd:id":"Q50624"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geom_alt":[
         "quattroshapes-reversegeo"
     ],
-    "wof:geomhash":"d8907395da5a3fa066f40e9ec43e910b",
+    "wof:geomhash":"ce0992cb9f267250e00c952ab2cfa64a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -460,7 +466,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1690849338,
+    "wof:lastmodified":1695885228,
     "wof:name":"Rogaland",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/856/870/89/85687089.geojson
+++ b/data/856/870/89/85687089.geojson
@@ -785,10 +785,16 @@
         "gn:id":3143242,
         "gp:id":2346395,
         "hasc:id":"NO.OS",
+        "iso:code":"NO-03",
         "iso:id":"NO-03",
+        "no-geonorge:number":"03",
         "unlc:id":"NO-03",
         "wd:id":"Q585"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         1159297167,
         1495123997
@@ -797,7 +803,7 @@
     "wof:geom_alt":[
         "quattroshapes-reversegeo"
     ],
-    "wof:geomhash":"a04bca4f5abb1fe24e00c4d0b6283d69",
+    "wof:geomhash":"d4cb579a4f4549533afa03ec3bc41979",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -817,7 +823,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1690849337,
+    "wof:lastmodified":1695885229,
     "wof:name":"Oslo",
     "wof:parent_id":85633341,
     "wof:placetype":"region",

--- a/data/856/871/23/85687123.geojson
+++ b/data/856/871/23/85687123.geojson
@@ -398,15 +398,21 @@
         "gn:id":3145495,
         "gp:id":2346391,
         "hasc:id":"NO.MR",
+        "iso:code":"NO-15",
         "iso:id":"NO-15",
+        "no-geonorge:number":"15",
         "unlc:id":"NO-15",
         "wd:id":"Q50627"
     },
+    "wof:concordances_official":"no-geonorge:number",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NO",
     "wof:geom_alt":[
         "quattroshapes-reversegeo"
     ],
-    "wof:geomhash":"fb2ba9f6c1862a61fdd95792045adaf2",
+    "wof:geomhash":"baf022ac5733a995a3f800be99488218",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -426,7 +432,7 @@
         "nno",
         "sme"
     ],
-    "wof:lastmodified":1690849347,
+    "wof:lastmodified":1695885230,
     "wof:name":"M\u00f8re og Romsdal",
     "wof:parent_id":85633341,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.